### PR TITLE
Fixed directory listings while using a 404.html

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -42,6 +42,10 @@ var ecstatic = module.exports = function (dir, options) {
           // This means we're already trying ./404.html
           status[404](res, next);
         }
+        else if(req.showDir) {
+          //We should show the directory is there is no index.html
+          next();
+        }
         else {
           // Try for ./404.html
           middleware({
@@ -64,7 +68,8 @@ var ecstatic = module.exports = function (dir, options) {
               };
 
         middleware({
-          url: path.join(pathname, '/index.html')
+          url: path.join(pathname, '/index.html'),
+          showDir: true
         }, res, handler);
       }
       else {


### PR DESCRIPTION
There was a problem before where showing the 404.html page took precedence over showing the directory listings. This problem should be fixed, as it now adds a bit of data that lets ecstatic know whether the request is from a directory listing request, and ecstatic can use that to know whether to show directory listings instead of the 404 page (the 404 originates from the lack of an index page in the directory).
