### PR TITLE
Added an example for Flatiron

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,24 @@ union.createServer({
 console.log('Listening on :8080');
 ```
 
+## flatiron
+
+``` js
+var flatiron = require('flatiron');
+var ecstatic = require('ecstatic');
+
+app = new flatiron.App();
+app.use(flatiron.plugins.http);
+
+app.http.before = [
+  ecstatic(__dirname + '/public')
+];
+
+app.start(8080);
+
+console.log('Listening on :8080');
+```
+
 # API:
 
 ## ecstatic(folder, opts={});


### PR DESCRIPTION
An example how to use ecstatic with Flatiron (the full-stack one, https://github.com/flatiron/flatiron). I don't know if this is obvious to all others, but at least I needed to check from sources how to add anything to the before chain since ecstatic is not a Broadway plugin.
