### PR TITLE
Fix Windows path - issue 23

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -11,7 +11,7 @@ var path = require('path'),
     optsParser = require('./ecstatic/opts');
 
 var ecstatic = module.exports = function (dir, options) {
-  var root = path.resolve(dir) + '/',
+  var root = path.join(path.resolve(dir), '/'),
       opts = optsParser(options),
       cache = opts.cache,
       autoIndex = opts.autoIndex;


### PR DESCRIPTION
Use path.join instead of concatenation in one rogue line
