### PR TITLE
[minor] Don't set `Date` header

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -25,7 +25,6 @@ var ecstatic = module.exports = function (dir, options) {
 
     // Set common headers.
     res.setHeader('server', 'ecstatic-'+version);
-    res.setHeader('date', (new Date()).toUTCString());
 
     if (file.slice(0, root.length) !== root) {
       return status[403](res, next);


### PR DESCRIPTION
node.js core does that already in more efficient way, as seen in
`lib/http.js`.
