### PR TITLE
Prevent double slash in href.

### DIFF
--- a/lib/ecstatic/showdir.js
+++ b/lib/ecstatic/showdir.js
@@ -57,7 +57,7 @@ module.exports = function (dir, pathname, stat, cache) {
               else {
                 files.push(file);
               }
-                
+
               if (--pending === 0) {
                 cb(errs, dirs, files);
               }
@@ -86,7 +86,7 @@ module.exports = function (dir, pathname, stat, cache) {
           var writeRow = function (file, i)  {
             html += '<tr><td>' + '<a href="'
               + ent.encode(encodeURI(
-                ((req.url == '/') ? '' : req.url)
+                req.url.replace(/\/$/, '')
                 + '/'
                 + file
               )) + '">' + ent.encode(file) + '</a></td></tr>';


### PR DESCRIPTION
For instance, if `req.url` is "/foo/bar/" the href for "baz.txt" should be "/foo/bar/baz.txt" instead of "/foo/bar//baz.txt".
