### PR TITLE
Fixes a hang when requesting a directory

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -105,8 +105,10 @@ var ecstatic = module.exports = function (dir, options) {
               return status[500](res, next, { error: err });
             }
             if (opts.showDir) {
-              showDir(opts, stat)(req, res);
+              return showDir(opts, stat)(req, res);
             }
+
+            return status[403](res, next);
           });
         }
 
@@ -196,4 +198,3 @@ function shouldCompress(req) {
       })
     ;
 };
-


### PR DESCRIPTION
The hang occurs when using autoIndex = true, and showDir = false and the request's target directory doesn't have an index.html file
