### PR TITLE
explain autoIndex

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Turn **on** directory listings with `opts.showDir === true`.
 
 ### `opts.autoIndex`
 
+Serve `/path/index.html` when `/path/` is requested.
 Turn **on** autoIndexing with `opts.autoIndex === true`. Defaults to **false**.
 
 ### `opts.defaultExt`


### PR DESCRIPTION
I had to read the code to figure if `autoIndex` did what I hoped it did, so I updated the documentation to explain more clearly.

It might be good if `autoIndex` was enabled by default.
I think the cases where you want that behaviour outnumber the cases where you don't.
