### PR TITLE
Don't rely on host header being present

### DIFF
--- a/lib/ecstatic/showdir.js
+++ b/lib/ecstatic/showdir.js
@@ -117,7 +117,7 @@ module.exports = function (opts, stat) {
             + process.version
             + '/<a href="https://github.com/jesusabdullah/node-ecstatic">ecstatic</a>'
             + ' server running @ '
-            + ent.encode(req.headers.host) + '</address>\n'
+            + ent.encode(req.headers.host || '') + '</address>\n'
             + '</body></html>'
           ;
 


### PR DESCRIPTION
Currently server crashes when requested without Host header(if showDir is true).

```
± % http-server -p 8181
Starting up http-server, serving ./ on port: 8181
Hit CTRL-C to stop the server
```

```
± % echo "GET / HTTP/1.1\n"  | nc 127.0.0.1 8181
```

```
± % http-server -p 8181
/usr/lib/node_modules/http-server/node_modules/ecstatic/node_modules/ent/index.js:12
        throw new TypeError('Expected a String');
              ^
TypeError: Expected a String
    at Object.exports.encode (/usr/lib/node_modules/http-server/node_modules/ecstatic/node_modules/ent/index.js:12:15)
    at module.exports (/usr/lib/node_modules/http-server/node_modules/ecstatic/lib/ecstatic/showdir.js:103:19)
    at module.exports.fs.readdir.sortByIsDirectory (/usr/lib/node_modules/http-server/node_modules/ecstatic/lib/ecstatic/showdir.js:62:17)
    at Object.oncomplete (fs.js:297:15)
```
