### PR TITLE
Let mime version float a bit.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "middleware"
   ],
   "dependencies": {
-    "mime": "1.2.7",
+    "mime": "1.2.x",
     "ent": "0.0.x",
     "optimist": "~0.3.5"
   },


### PR DESCRIPTION
Given that minor updates just fix or add to the mime types list, this should be safe.

In particular, this will allow ecstatic to set font mime types correctly once broofa/node-mime#63 is resolved.
