### PR TITLE
Fix redirect location for escaped URI

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -106,7 +106,7 @@ var ecstatic = module.exports = function (dir, options) {
         // 302 to / if necessary
         if (!pathname.match(/\/$/)) {
           res.statusCode = 302;
-          res.setHeader('location', pathname + '/' + (
+          res.setHeader('location', parsed.pathname + '/' + (
             parsed.query ? '?' + parsed.query : ''
           ));
           return res.end();


### PR DESCRIPTION
Set redirect location to pristine `parsed.pathname` instead of url-decoded `pathname`
