### PR TITLE
Refactoring test/

### DIFF
--- a/test/common-testCases-error.js
+++ b/test/common-testCases-error.js
@@ -1,0 +1,12 @@
+exports.testCases = {
+  '404' : {
+    code: 404
+  },
+  'something non-existant' : {
+    code: 404
+  }
+};
+
+if (require.main === module) {
+  console.log("ok 1 - test cases (error) included");
+}

--- a/test/common-testCases.js
+++ b/test/common-testCases.js
@@ -1,0 +1,107 @@
+exports.testCases = {
+  'a.txt' : {
+    code : 200,
+    type : 'text/plain',
+    body : 'A!!!\n',
+  },
+  'b.txt' : {
+    code : 200,
+    type : 'text/plain',
+    body : 'B!!!\n',
+  },
+  'c.js' : {
+    code : 200,
+    type : 'application/javascript',
+    body : 'console.log(\'C!!!\');\n',
+  },
+  'd.js' : {
+    code : 200,
+    type : 'application/javascript',
+    body : 'console.log(\'C!!!\');\n',
+  },
+  'subdir/e.html' : {
+    code : 200,
+    type : 'text/html',
+    body : '<b>e!!</b>\n',
+  },
+  // test for defaultExt
+  'subdir/e?foo=bar' : {
+    code : 200,
+    type : 'text/html',
+    body : '<b>e!!</b>\n',
+  },
+  // test for defaultExt with noisy query param
+  'subdir/e?foo=bar.ext' : {
+    code : 200,
+    type : 'text/html',
+    body : '<b>e!!</b>\n',
+  },
+  'subdir/index.html' : {
+    code : 200,
+    type : 'text/html',
+    body : 'index!!!\n',
+  },
+  'subdir' : {
+    code : 302,
+    location: 'subdir/'
+  },
+  'subdir?foo=bar': {
+    code: 302,
+    location: 'subdir/?foo=bar'
+  },
+  // test for url-encoded paths
+  '%E4%B8%AD%E6%96%87' : {  // '/中文'
+    code : 302,
+    location: '%E4%B8%AD%E6%96%87/'
+  },
+  '%E4%B8%AD%E6%96%87?%E5%A4%AB=%E5%B7%B4': {  // '中文?夫=巴'
+    code: 302,
+    location: '%E4%B8%AD%E6%96%87/?%E5%A4%AB=%E5%B7%B4'
+  },
+  'subdir/' : {
+    code : 200,
+    type : 'text/html',
+    body : 'index!!!\n'
+  },
+  '404' : {
+    code : 200,
+    type : 'text/html',
+    body : '<h1>404</h1>\n'
+  },
+  'something-non-existant' : {
+    code : 200,
+    type : 'text/html',
+    body : '<h1>404</h1>\n'
+  },
+  'compress/foo.js' : {
+    code : 200,
+    file: 'compress/foo.js.gz',
+    headers: {'accept-encoding': 'compress, gzip'}
+  },
+  // no accept-encoding of gzip, so serve regular file
+  'compress/foo_2.js' : {
+    code : 200,
+    file: 'compress/foo_2.js'
+  },
+  'emptyDir/': {
+    code: 200
+  },
+  'subdir_with space' : {
+    code: 302,
+    location: 'subdir_with%20space/'
+  },
+  'subdir_with space/index.html' : {
+    code: 200,
+    type: 'text/html',
+    body: 'index :)\n'
+  },
+  'something-non-existant%00.png': {
+    code: 200,
+    type: 'text/html',
+    body: '<h1>404</h1>\n'
+  }
+};
+
+if (require.main === module) {
+  console.log("ok 1 - test cases included");
+}

--- a/test/core-handleError.js
+++ b/test/core-handleError.js
@@ -11,19 +11,12 @@ var root = __dirname + '/public',
 
 mkdirp.sync(root + '/emptyDir');
 
-var files = {
-  '404' : {
-    code : 404
-  },
-  'something-non-existant' : {
-    code : 404
-  }
-};
+var testCases = require('./common-testCases-error').testCases;
 
 test('core', function (t) {
-  var filenames = Object.keys(files);
+  var filenames = Object.keys(testCases);
   var port = Math.floor(Math.random() * ((1<<16) - 1e4) + 1e4);
-  
+
   var server = http.createServer(
     ecstatic({
       root: root,
@@ -39,7 +32,7 @@ test('core', function (t) {
     var pending = filenames.length;
     filenames.forEach(function (file) {
       var uri = 'http://localhost:' + port + path.join('/', baseDir, file),
-          headers = files[file].headers || {};
+          headers = testCases[file].headers || {};
 
       request.get({
         uri: uri,
@@ -47,16 +40,16 @@ test('core', function (t) {
         headers: headers
       }, function (err, res, body) {
         if (err) t.fail(err);
-        var r = files[file];
+        var r = testCases[file];
         t.equal(res.statusCode, r.code, 'status code for `' + file + '`');
-        
+
         if (r.type !== undefined) {
           t.equal(
             res.headers['content-type'].split(';')[0], r.type,
             'content-type for `' + file + '`'
           );
         }
-        
+
         if (r.body !== undefined) {
           t.equal(body, r.body, 'body for `' + file + '`');
         }
@@ -64,7 +57,7 @@ test('core', function (t) {
         if (r.location !== undefined) {
           t.equal(res.headers.location, path.join('/', baseDir, r.location), 'location for `' + file + '`');
         }
-        
+
         if (--pending === 0) {
           server.close();
           t.end();

--- a/test/core.js
+++ b/test/core.js
@@ -11,112 +11,10 @@ var root = __dirname + '/public',
 
 mkdirp.sync(root + '/emptyDir');
 
-var files = {
-  'a.txt' : {
-    code : 200,
-    type : 'text/plain',
-    body : 'A!!!\n',
-  },
-  'b.txt' : {
-    code : 200,
-    type : 'text/plain',
-    body : 'B!!!\n',
-  },
-  'c.js' : {
-    code : 200,
-    type : 'application/javascript',
-    body : 'console.log(\'C!!!\');\n',
-  },
-  'd.js' : {
-    code : 200,
-    type : 'application/javascript',
-    body : 'console.log(\'C!!!\');\n',
-  },
-  'subdir/e.html' : {
-    code : 200,
-    type : 'text/html',
-    body : '<b>e!!</b>\n',
-  },
-  // test for defaultExt
-  'subdir/e?foo=bar' : {
-    code : 200,
-    type : 'text/html',
-    body : '<b>e!!</b>\n',
-  },
-  // test for defaultExt with noisy query param
-  'subdir/e?foo=bar.ext' : {
-    code : 200,
-    type : 'text/html',
-    body : '<b>e!!</b>\n',
-  },
-  'subdir/index.html' : {
-    code : 200,
-    type : 'text/html',
-    body : 'index!!!\n',
-  },
-  'subdir' : {
-    code : 302,
-    location: 'subdir/'
-  },
-  'subdir?foo=bar': {
-    code: 302,
-    location: 'subdir/?foo=bar'
-  },
-  // test for url-encoded paths
-  '%E4%B8%AD%E6%96%87' : {  // '/中文'
-    code : 302,
-    location: '%E4%B8%AD%E6%96%87/'
-  },
-  '%E4%B8%AD%E6%96%87?%E5%A4%AB=%E5%B7%B4': {  // '中文?夫=巴'
-    code: 302,
-    location: '%E4%B8%AD%E6%96%87/?%E5%A4%AB=%E5%B7%B4'
-  },
-  'subdir/' : {
-    code : 200,
-    type : 'text/html',
-    body : 'index!!!\n'
-  },
-  '404' : {
-    code : 200,
-    type : 'text/html',
-    body : '<h1>404</h1>\n'
-  },
-  'something-non-existant' : {
-    code : 200,
-    type : 'text/html',
-    body : '<h1>404</h1>\n'
-  },
-  'compress/foo.js' : {
-    code : 200,
-    file: 'compress/foo.js.gz',
-    headers: {'accept-encoding': 'compress, gzip'}
-  },
-  // no accept-encoding of gzip, so serve regular file
-  'compress/foo_2.js' : {
-    code : 200,
-    file: 'compress/foo_2.js'
-  },
-  'emptyDir/': {
-    code: 200
-  },
-  'subdir_with space' : {
-    code: 302,
-    location: 'subdir_with%20space/'
-  },
-  'subdir_with space/index.html' : {
-    code: 200,
-    type: 'text/html',
-    body: 'index :)\n'
-  },
-  'something-non-existant%00.png': {
-    code: 200,
-    type: 'text/html',
-    body: '<h1>404</h1>\n'
-  }
-};
+var testCases = require('./common-testCases').testCases;
 
 test('core', function (t) {
-  var filenames = Object.keys(files);
+  var filenames = Object.keys(testCases);
   var port = Math.floor(Math.random() * ((1<<16) - 1e4) + 1e4);
 
   var server = http.createServer(
@@ -135,7 +33,7 @@ test('core', function (t) {
     var pending = filenames.length;
     filenames.forEach(function (file) {
       var uri = 'http://localhost:' + port + path.join('/', baseDir, file),
-          headers = files[file].headers || {};
+          headers = testCases[file].headers || {};
 
       request.get({
         uri: uri,
@@ -143,7 +41,7 @@ test('core', function (t) {
         headers: headers
       }, function (err, res, body) {
         if (err) t.fail(err);
-        var r = files[file];
+        var r = testCases[file];
         t.equal(res.statusCode, r.code, 'status code for `' + file + '`');
 
         if (r.type !== undefined) {

--- a/test/express-handleError.js
+++ b/test/express-handleError.js
@@ -12,19 +12,12 @@ var root = __dirname + '/public',
 
 mkdirp.sync(root + '/emptyDir');
 
-var files = {
-  '404' : {
-    code: 404
-  },
-  'something non-existant' : {
-    code: 404
-  }
-};
+var testCases = require('./common-testCases-error').testCases;
 
 test('express', function (t) {
-  var filenames = Object.keys(files);
+  var filenames = Object.keys(testCases);
   var port = Math.floor(Math.random() * ((1<<16) - 1e4) + 1e4);
-  
+
   var app = express();
 
   app.use(ecstatic({
@@ -43,7 +36,7 @@ test('express', function (t) {
     var pending = filenames.length;
     filenames.forEach(function (file) {
       var uri = 'http://localhost:' + port + path.join('/', baseDir, file),
-          headers = files[file].headers || {};
+          headers = testCases[file].headers || {};
 
       request.get({
         uri: uri,
@@ -51,24 +44,24 @@ test('express', function (t) {
         headers: headers
       }, function (err, res, body) {
         if (err) t.fail(err);
-        var r = files[file];
+        var r = testCases[file];
         t.equal(res.statusCode, r.code, 'status code for `' + file + '`');
 
         if (r.code === 200) {
             t.equal(res.headers['cache-control'], 'no-cache', 'cache control for `' + file + '`');
         };
-        
+
         if (r.type !== undefined) {
           t.equal(
             res.headers['content-type'].split(';')[0], r.type,
             'content-type for `' + file + '`'
           );
         }
-        
+
         if (r.body !== undefined) {
           t.equal(body, r.body, 'body for `' + file + '`');
         }
-        
+
         if (--pending === 0) {
           server.close();
           t.end();

--- a/test/express.js
+++ b/test/express.js
@@ -12,74 +12,12 @@ var root = __dirname + '/public',
 
 mkdirp.sync(root + '/emptyDir');
 
-var files = {
-  'a.txt' : {
-    code : 200,
-    type : 'text/plain',
-    body : 'A!!!\n',
-  },
-  'b.txt' : {
-    code : 200,
-    type : 'text/plain',
-    body : 'B!!!\n',
-  },
-  'c.js' : {
-    code : 200,
-    type : 'application/javascript',
-    body : 'console.log(\'C!!!\');\n',
-  },
-  'd.js' : {
-    code : 200,
-    type : 'application/javascript',
-    body : 'console.log(\'C!!!\');\n',
-  },
-  'subdir/e.html' : {
-    code : 200,
-    type : 'text/html',
-    body : '<b>e!!</b>\n',
-  },
-  'subdir/index.html' : {
-    code : 200,
-    type : 'text/html',
-    body : 'index!!!\n',
-  },
-  'subdir' : {
-    code : 302
-  },
-  'subdir/' : {
-    code : 200,
-    type : 'text/html',
-    body : 'index!!!\n',
-  },
-  '404' : {
-    code : 200,
-    type : 'text/html',
-    body : '<h1>404</h1>\n'
-  },
-  'something-non-existant' : {
-    code : 200,
-    type : 'text/html',
-    body : '<h1>404</h1>\n'
-  },
-  'compress/foo.js' : {
-    code : 200,
-    file: 'compress/foo.js.gz',
-    headers: {'accept-encoding': 'compress, gzip'}
-  },
-  // no accept-encoding of gzip, so serve regular file
-  'compress/foo_2.js' : {
-    code : 200,
-    file: 'compress/foo_2.js' 
-  },
-  'emptyDir/': {
-    code: 200
-  }
-};
+var testCases = require('./common-testCases').testCases;
 
 test('express', function (t) {
-  var filenames = Object.keys(files);
+  var filenames = Object.keys(testCases);
   var port = Math.floor(Math.random() * ((1<<16) - 1e4) + 1e4);
-  
+
   var app = express();
 
   app.use(ecstatic({
@@ -88,6 +26,7 @@ test('express', function (t) {
     baseDir: baseDir,
     autoIndex: true,
     showDir: true,
+    defaultExt: 'html',
     cache: "no-cache",
     handleError: true
   }));
@@ -98,7 +37,7 @@ test('express', function (t) {
     var pending = filenames.length;
     filenames.forEach(function (file) {
       var uri = 'http://localhost:' + port + path.join('/', baseDir, file),
-          headers = files[file].headers || {};
+          headers = testCases[file].headers || {};
 
       request.get({
         uri: uri,
@@ -106,24 +45,24 @@ test('express', function (t) {
         headers: headers
       }, function (err, res, body) {
         if (err) t.fail(err);
-        var r = files[file];
+        var r = testCases[file];
         t.equal(res.statusCode, r.code, 'status code for `' + file + '`');
 
         if (r.code === 200) {
             t.equal(res.headers['cache-control'], 'no-cache', 'cache control for `' + file + '`');
-        };
-        
+        }
+
         if (r.type !== undefined) {
           t.equal(
             res.headers['content-type'].split(';')[0], r.type,
             'content-type for `' + file + '`'
           );
         }
-        
+
         if (r.body !== undefined) {
           t.equal(body, r.body, 'body for `' + file + '`');
         }
-        
+
         if (--pending === 0) {
           server.close();
           t.end();

--- a/test/union-handleError.js
+++ b/test/union-handleError.js
@@ -11,19 +11,12 @@ var root = __dirname + '/public',
 
 mkdirp.sync(root + '/emptyDir');
 
-var files = {
-  '404' : {
-    code : 404
-  },
-  'something-non-existant' : {
-    code : 404
-  }
-};
+var testCases = require('./common-testCases-error').testCases;
 
 test('union', function (t) {
-  var filenames = Object.keys(files);
+  var filenames = Object.keys(testCases);
   var port = Math.floor(Math.random() * ((1<<16) - 1e4) + 1e4);
-  
+
   var server = union.createServer({
     before: [
       ecstatic({
@@ -41,7 +34,7 @@ test('union', function (t) {
     var pending = filenames.length;
     filenames.forEach(function (file) {
       var uri = 'http://localhost:' + port + path.join('/', baseDir, file),
-          headers = files[file].headers || {};
+          headers = testCases[file].headers || {};
 
       request.get({
         uri: uri,
@@ -49,20 +42,20 @@ test('union', function (t) {
         headers: headers
       }, function (err, res, body) {
         if (err) t.fail(err);
-        var r = files[file];
+        var r = testCases[file];
         t.equal(res.statusCode, r.code, 'status code for `' + file + '`');
-        
+
         if (r.type !== undefined) {
           t.equal(
             res.headers['content-type'].split(';')[0], r.type,
             'content-type for `' + file + '`'
           );
         }
-        
+
         if (r.body !== undefined) {
           t.equal(body, r.body, 'body for `' + file + '`');
         }
-        
+
         if (--pending === 0) {
           server.close();
           t.end();


### PR DESCRIPTION
Pull test cases to `common-testCases.js` and `common-testCases-error.js`.
Framework tests then includes these files to reduces duplication and make tests more consistent between the frameworks.

This is a prelim step in re-factoring, some point we may wish to achieve:
- test file listing (`showDir()`)
- test options independently (options specific test cases?)
- ...
