### PR TITLE
Fix gzip requests being fired twice

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -67,78 +67,85 @@ var ecstatic = module.exports = function (dir, options) {
       return status[405](res, next);
     }
 
+    function statFile() {
+      fs.stat(file, function (err, stat) {
+        if (err && err.code === 'ENOENT') {
+          if (req.statusCode == 404) {
+            // This means we're already trying ./404.html
+            status[404](res, next);
+          }
+          else if (defaultExt && !path.extname(parsed.pathname).length) {
+            //
+            // If no file extension is specified and there is a default extension
+            // try that before rendering 404.html.
+            //
+            middleware({
+              url: parsed.pathname + '.' + defaultExt + ((parsed.search)? parsed.search:'')
+            }, res, next);
+          }
+          else {
+            // Try for ./404.html
+            middleware({
+              url: (handleError ? ('/' + path.join(baseDir, '404.html')) : req.url),
+              statusCode: 404 // Override the response status code
+            }, res, next);
+          }
+        }
+        else if (err) {
+          status[500](res, next, { error: err });
+        }
+        else if (stat.isDirectory()) {
+          // 302 to / if necessary
+          if (!parsed.pathname.match(/\/$/)) {
+            res.statusCode = 302;
+            res.setHeader('location', parsed.pathname + '/' +
+              (parsed.query? ('?' + parsed.query):'')
+            );
+            return res.end();
+          }
+
+          if (autoIndex) {
+            return middleware({
+              url: path.join(pathname, '/index.html')
+            }, res, function (err) {
+              if (err) {
+                return status[500](res, next, { error: err });
+              }
+              if (opts.showDir) {
+                return showDir(opts, stat)(req, res);
+              }
+
+              return status[403](res, next);
+            });
+          }
+
+          if (opts.showDir) {
+            return showDir(opts, stat)(req, res);
+          }
+
+          status[404](res, next);
+
+        }
+        else {
+          serve(stat);
+        }
+      });
+
+    }
+
     // Look for a gzipped file if this is turned on
     if (opts.gzip && shouldCompress(req)) {
       fs.stat(gzipped, function (err, stat) {
         if (!err && stat.isFile()) {
           file = gzipped;
           return serve(stat);
+        } else {
+          statFile();
         }
       });
+    } else {
+      statFile();
     }
-
-    fs.stat(file, function (err, stat) {
-      if (err && err.code === 'ENOENT') {
-        if (req.statusCode == 404) {
-          // This means we're already trying ./404.html
-          status[404](res, next);
-        }
-        else if (defaultExt && !path.extname(parsed.pathname).length) {
-          //
-          // If no file extension is specified and there is a default extension
-          // try that before rendering 404.html.
-          //
-          middleware({
-            url: parsed.pathname + '.' + defaultExt + ((parsed.search)? parsed.search:'')
-          }, res, next);
-        }
-        else {
-          // Try for ./404.html
-          middleware({
-            url: (handleError ? ('/' + path.join(baseDir, '404.html')) : req.url),
-            statusCode: 404 // Override the response status code
-          }, res, next);
-        }
-      }
-      else if (err) {
-        status[500](res, next, { error: err });
-      }
-      else if (stat.isDirectory()) {
-        // 302 to / if necessary
-        if (!parsed.pathname.match(/\/$/)) {
-          res.statusCode = 302;
-          res.setHeader('location', parsed.pathname + '/' +
-            (parsed.query? ('?' + parsed.query):'')
-          );
-          return res.end();
-        }
-
-        if (autoIndex) {
-          return middleware({
-            url: path.join(pathname, '/index.html')
-          }, res, function (err) {
-            if (err) {
-              return status[500](res, next, { error: err });
-            }
-            if (opts.showDir) {
-              return showDir(opts, stat)(req, res);
-            }
-
-            return status[403](res, next);
-          });
-        }
-
-        if (opts.showDir) {
-          return showDir(opts, stat)(req, res);
-        }
-
-        status[404](res, next);
-
-      }
-      else {
-        serve(stat);
-      }
-    });
 
     function serve(stat) {
 


### PR DESCRIPTION
Hey! For a while at DIY, we had abstained from having gzip enabled for static files, because they would hang on our servers. I decided to properly look into that today, and found the issue. What was happening was that inside the check on the `fs.stat` of the `gzipped` file, it was calling return, but inside the `fs.stat` scope. This means that it wasn't doing a returning in the scope before, which caused `fs.stat` to be called twice, along with `serve`. This lead to the wrong file and stats being returned, which caused the hang.

I fixed it by scoping the non-gzipped file stat check inside a function. It's a messy solution, so I'm open to any changes that would make it better.
