### PR TITLE
Add files directive to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,14 @@
     "test": "tap test/*.js"
   },
   "bin": "./lib/ecstatic.js",
+  "files": [
+    "LICENSE.txt",
+    "lib/ecstatic.js",
+    "lib/ecstatic/etag.js",
+    "lib/ecstatic/opts.js",
+    "lib/ecstatic/showdir.js",
+    "lib/ecstatic/status-handlers.js"
+  ],
   "keywords": [
     "static",
     "web",


### PR DESCRIPTION
Limit files available to `npm` to prevent unnecessary downloads of test directory.
