### PR TITLE
Simplify `undefined` and `null` detection

### DIFF
--- a/lib/ecstatic/opts.js
+++ b/lib/ecstatic/opts.js
@@ -16,7 +16,7 @@ module.exports = function (opts) {
       'autoIndex',
       'autoindex'
     ].some(function (k) {
-      if (typeof opts[k] !== 'undefined' && opts[k] !== null) {
+      if (opts[k] != null) {
         autoIndex = opts[k];
         return true;
       }
@@ -26,7 +26,7 @@ module.exports = function (opts) {
       'showDir',
       'showdir'
     ].some(function (k) {
-      if (typeof opts[k] !== 'undefined' && opts[k] !== null) {
+      if (opts[k] != null) {
         showDir = opts[k];
         return true;
       }
@@ -37,7 +37,7 @@ module.exports = function (opts) {
       'humanreadable',
       'human-readable'
     ].some(function (k) {
-      if (typeof opts[k] !== 'undefined' && opts[k] !== null) {
+      if (opts[k] != null) {
         humanReadable = opts[k];
         return true;
       }
@@ -47,7 +47,7 @@ module.exports = function (opts) {
       'si',
       'index'
     ].some(function (k) {
-      if (typeof opts[k] !== 'undefined' && opts[k] !== null) {
+      if (opts[k] != null) {
         si = opts[k];
         return true;
       }
@@ -62,7 +62,7 @@ module.exports = function (opts) {
       }
     }
 
-    if (typeof opts.cache !== 'undefined' && opts.cache !== null) {
+    if (opts.cache != null) {
       if (typeof opts.cache === 'string') {
         cache = opts.cache;
       }
@@ -71,7 +71,7 @@ module.exports = function (opts) {
       }
     }
 
-    if (typeof opts.gzip !== 'undefined' && opts.gzip !== null) {
+    if (opts.gzip != null) {
       gzip = opts.gzip;
     }
 
@@ -79,7 +79,7 @@ module.exports = function (opts) {
       'handleError',
       'handleerror'
     ].some(function (k) {
-        if (typeof opts[k] !== 'undefined' && opts[k] !== null) {
+        if (opts[k] != null) {
             handleError = opts[k];
             return true;
         }


### PR DESCRIPTION
Instead of using `typeof x !== "undefined" && x !== null`,
use a simpler `x != null` instead.
