### PR TITLE
Implements a decodeFilename function to use instead of decodeURI. fixes #109

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -38,7 +38,7 @@ var ecstatic = module.exports = function (dir, options) {
     var parsed = url.parse(req.url);
     try {
       decodeURI(req.url); // check validity of url
-      var pathname = decodeURI(parsed.pathname);
+      var pathname = decodePathname(parsed.pathname);
     }
     catch (err) {
       return status[400](res, next, { error: err });
@@ -226,6 +226,32 @@ function shouldCompress(req) {
         return ['*','compress', 'gzip', 'deflate'].indexOf(el) != -1;
       })
     ;
+}
+
+// Helper var to apply specific fixes in decoding pathname
+var isWin = (process.platform == 'win32');
+
+// Decodes the path to the file being served considering that
+// the path components can contain encoded entities
+// https://github.com/jesusabdullah/node-ecstatic/issues/109
+function decodePathname(pathname) {
+  //if (/%2f/i.test(pathname))
+    //throw new Error('Invalid encoded slash character');
+
+  var pieces = pathname.split('/');
+  var single_piece;
+
+  for (var i = 0, l = pieces.length; i < l; i += 1) {
+    single_piece = decodeURIComponent(pieces[i]);
+
+    if (isWin && /\\/.test(single_piece)) {
+      throw new Error('Invalid forward slash character');
+    }
+
+    pieces[i] = single_piece;
+  }
+
+  return pieces.join('/');
 }
 
 if(!module.parent) {


### PR DESCRIPTION
Implements a decodeFilename function to use instead of decodeURI on decoding the path of the file being served from the url.
