### PR TITLE
Use `he` for robust HTML entity encoding/decoding

### DIFF
--- a/lib/ecstatic/showdir.js
+++ b/lib/ecstatic/showdir.js
@@ -1,7 +1,7 @@
 var ecstatic = require('../ecstatic'),
     fs = require('fs'),
     path = require('path'),
-    ent = require('ent'),
+    he = require('he'),
     etag = require('./etag'),
     url = require('url'),
     status = require('./status-handlers');
@@ -122,7 +122,7 @@ module.exports = function (opts, stat) {
               href += '/' + ((parsed.search)? parsed.search:'');
             }
 
-            var displayName = ent.encode(file[0]) + ((isDir)? '/':'');
+            var displayName = he.encode(file[0]) + ((isDir)? '/':'');
 
             // TODO: use stylessheets?
             html += '<tr>' +
@@ -140,7 +140,7 @@ module.exports = function (opts, stat) {
             process.version +
             '/ <a href="https://github.com/jesusabdullah/node-ecstatic">ecstatic</a> ' +
             'server running @ ' +
-            ent.encode(req.headers.host || '') + '</address>\n' +
+            he.encode(req.headers.host || '') + '</address>\n' +
             '</body></html>'
           ;
 

--- a/lib/ecstatic/status-handlers.js
+++ b/lib/ecstatic/status-handlers.js
@@ -26,7 +26,7 @@ exports['405'] = function (res, next, opts) {
   }
   else {
     res.setHeader('allow', (opts && opts.allow) || 'GET, HEAD');
-    res.end();    
+    res.end();
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "middleware"
   ],
   "dependencies": {
+    "he": "~0.4.1",
     "mime": "1.2.x",
-    "ent": "0.0.x",
     "minimist": "~0.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
_ent_ has [several open issues](https://github.com/substack/node-ent/issues/created_by/mathiasbynens?state=open) that are not present in [_he_](http://mths.be/he).
