### PR TITLE
fix defaultExt by removing dot

### DIFF
--- a/lib/ecstatic/opts.js
+++ b/lib/ecstatic/opts.js
@@ -8,7 +8,7 @@ module.exports = function (opts) {
       si = false,
       cache = 'max-age=3600',
       gzip = false,
-      defaultExt = '.html',
+      defaultExt = 'html',
       handleError = true;
 
   if (opts) {


### PR DESCRIPTION
Noticed I couldn't get autoIndex to work without specifying a defaultExt: 'html'.
Put in some console.logs and saw it was trying to load files named `x/index..html`.
