### PR TITLE
Include .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -15,3 +15,6 @@ results
 
 node_modules
 npm-debug.log
+
+# NPM-specific (in git, but not downloaded with `npm install`)
+test


### PR DESCRIPTION
If no `.npmignore` file is included, `.gitignore` is used by default. Thus, everything in `.gitignore` would typically end up in the `.npmignore` file.

The `.npmignore` file I've added uses the `.gitignore` as a base, and adds the `test` directory to resolve #128. Further, I've added a note to the `.gitignore` to help ensure future modifications there get added to the `.npmignore` too.

With this change, those that `npm install` the package won't get the tests, but they likely don't need them. If they're going to be running tests against this module, they'll likely be cloning the repo in the first place.

https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package