### PR TITLE
Add option to disable 'Server' header

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ var opts = {
              humanReadable : true,
              si            : false,
              defaultExt    : 'html',
-             gzip          : false
+             gzip          : false,
+             serverHeader  : true
            }
 ```
 
@@ -127,6 +128,11 @@ to resolve to `./public/a-file.html`, set this to `true`. If you want
 Set `opts.gzip === true` in order to turn on "gzip mode," wherein ecstatic will
 serve `./public/some-file.js.gz` in place of `./public/some-file.js` when the
 gzipped version exists and ecstatic determines that the behavior is appropriate.
+
+### `opts.serverHeader`
+
+Set `opts.serverHeader` to false in order to turn off setting the `Server` header
+on all responses served by ecstatic.
 
 ### `opts.handleError`
 

--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -24,7 +24,8 @@ var ecstatic = module.exports = function (dir, options) {
       autoIndex = opts.autoIndex,
       baseDir = opts.baseDir,
       defaultExt = opts.defaultExt,
-      handleError = opts.handleError;
+      handleError = opts.handleError,
+      serverHeader = opts.serverHeader;
 
   opts.root = dir;
   if (defaultExt && /^\./.test(defaultExt)) defaultExt = defaultExt.replace(/^\./, '');
@@ -55,8 +56,10 @@ var ecstatic = module.exports = function (dir, options) {
         ),
         gzipped = file + '.gz';
 
-    // Set common headers.
-    res.setHeader('server', 'ecstatic-'+version);
+    if(serverHeader !== false) {
+      // Set common headers.
+      res.setHeader('server', 'ecstatic-'+version);
+    }
 
     // TODO: This check is broken, which causes the 403 on the
     // expected 404.

--- a/lib/ecstatic/opts.js
+++ b/lib/ecstatic/opts.js
@@ -9,7 +9,8 @@ module.exports = function (opts) {
       cache = 'max-age=3600',
       gzip = false,
       defaultExt = '.html',
-      handleError = true;
+      handleError = true,
+      serverHeader = true;
 
   if (opts) {
     [
@@ -79,6 +80,18 @@ module.exports = function (opts) {
             return true;
         }
     });
+
+    [
+      'serverHeader',
+      'serverheader',
+      'server-header'
+    ].some(function (k) {
+        if (typeof opts[k] !== 'undefined' && opts[k] !== null) {
+            serverHeader = opts[k];
+            return true;
+        }
+    });
+
   }
 
   return {
@@ -90,6 +103,7 @@ module.exports = function (opts) {
     defaultExt: defaultExt,
     baseDir: (opts && opts.baseDir) || '/',
     gzip: gzip,
-    handleError: handleError
+    handleError: handleError,
+    serverHeader: serverHeader
   };
 };

--- a/test/server-header.js
+++ b/test/server-header.js
@@ -1,0 +1,32 @@
+var test = require('tap').test,
+    ecstatic = require('../'),
+    http = require('http'),
+    request = require('request');
+
+test('serverHeader should exist', function (t) {
+  t.plan(2);
+  var server = http.createServer(ecstatic(__dirname + '/public/subdir'));
+  t.on('end', function () { server.close() })
+  server.listen(0, function () {
+    var port = server.address().port;
+    request.get('http://localhost:' + port, function (err, res, body) {
+      t.ifError(err);
+      t.equal(res.headers.server, 'ecstatic-' + ecstatic.version);
+    });
+  });
+});
+
+test('serverHeader should not exist', function (t) {
+  t.plan(2);
+  var server = http.createServer(ecstatic(__dirname + '/public/subdir', {
+    serverHeader: false
+  }));
+  t.on('end', function () { server.close() })
+  server.listen(0, function () {
+    var port = server.address().port;
+    request.get('http://localhost:' + port, function (err, res, body) {
+      t.ifError(err);
+      t.equal(res.headers.server, undefined);
+    });
+  });
+});


### PR DESCRIPTION
As the title says, this PR adds the ability to disable the 'Server' header for all responses that ecstatic handles.