### PR TITLE
Fix path splitting to account for Windows paths

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -255,7 +255,7 @@ function shouldCompress(req) {
 
 // See: https://github.com/jesusabdullah/node-ecstatic/issues/109
 function decodePathname(pathname) {
-  var pieces = pathname.split('/');
+  var pieces = pathname.replace(/\\/g,"/").split('/');
 
   return pieces.map(function (piece) {
     piece = decodeURIComponent(piece);


### PR DESCRIPTION
This fixes an issue I hit using http-server to run a simple test site, and I can see others have reported this also (e.g. https://github.com/nodeapps/http-server/issues/122 ).

Basically, path.join is used in places (such as @ line 117: `url: path.join(encodeURIComponent(pathname), '/index.' + defaultExt)`), and this results in backslashes in the URL on Windows.  This causes failures in the decodePathname function, as it only handles forward slashes when breaking apart the paths.  This change simply handles backslashes as well as forward slashes to split the path before trying to decode the parts.  This fixes the issue for me.

Note the line called out above (117) looks suspect also, so the correct fix may actually be here.  For example, when just running 'http-server' and requesting the root of the site ( http://localhost:8080/ ), pathname == "/".  This is URI encoded to "%2F", then path.joined to "/index.html", which on Windows results in "%2F\\index.html".  Even on a forward-slash system this would result in "%2F/index.html" - which seems wrong.

I'd also note trying to run the tests with "npm test" doesn't work for me - either before or after this change.  Most tests fail with `TypeError: Cannot read property 'statusCode' of undefined`.  Not sure if this is Windows specific or not.  I didn't have time to investigate further.