### PR TITLE
Bugfix: `handleErrors` is ignored when using `showDir`

### DIFF
--- a/lib/ecstatic/showdir.js
+++ b/lib/ecstatic/showdir.js
@@ -12,6 +12,7 @@ module.exports = function (opts, stat) {
       root = path.resolve(opts.root),
       baseDir = opts.baseDir,
       humanReadable = opts.humanReadable,
+      handleError = opts.handleError,
       si = opts.si;
 
   return function middleware (req, res, next) {
@@ -30,13 +31,13 @@ module.exports = function (opts, stat) {
 
     fs.stat(dir, function (err, stat) {
       if (err) {
-        return status[500](res, next, { error: err });
+        return handleError ? status[500](res, next, { error: err }) : next();
       }
 
       // files are the listing of dir
       fs.readdir(dir, function (err, files) {
         if (err) {
-          return status[500](res, next, { error: err });
+          return handleError ? status[500](res, next, { error: err }) : next();
         }
         res.setHeader('content-type', 'text/html');
         res.setHeader('etag', etag(stat));
@@ -56,7 +57,7 @@ module.exports = function (opts, stat) {
           if (path.resolve(dir, '..').slice(0, root.length) == root) {
             return fs.stat(path.join(dir, '..'), function (err, s) {
               if (err) {
-                return status[500](res, next, { error: err });
+                return handleError ? status[500](res, next, { error: err }) : next();
               }
               dirs.unshift([ '..', s ]);
               render(dirs, files, lolwuts);


### PR DESCRIPTION
I would like to use the *proxy-middleware* if the request cannot be resolved locally.
However right now `handleErrors = false` is ignored if `showDir` is set to `true` and the directory does not exists and displays a error page instead.