### PR TITLE
Fix autoIndex path (index.html) for Windows

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -117,7 +117,7 @@ var ecstatic = module.exports = function (dir, options) {
 
           if (autoIndex) {
             return middleware({
-              url: path.join(encodeURIComponent(pathname), '/index.' + defaultExt)
+              url: path.join(encodeURIComponent(pathname), '/index.' + defaultExt).replace(/\\/g,"/")
             }, res, function (err) {
               if (err) {
                 return status[500](res, next, { error: err });


### PR DESCRIPTION
I use `autoIndex` option and got an error.
```
Error: Invalid forward slash character
```
In Windows, `path.join` uses separator `\`. So I replace it with `/`.