### PR TITLE
Handle ENOTDIR as 404

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -74,7 +74,7 @@ var ecstatic = module.exports = function (dir, options) {
 
     function statFile() {
       fs.stat(file, function (err, stat) {
-        if (err && err.code === 'ENOENT') {
+        if (err && (err.code === 'ENOENT' || err.code === 'ENOTDIR')) {
           if (req.statusCode == 404) {
             // This means we're already trying ./404.html
             status[404](res, next);

--- a/test/enotdir.js
+++ b/test/enotdir.js
@@ -1,0 +1,18 @@
+var test = require('tap').test,
+    ecstatic = require('../'),
+    http = require('http'),
+    request = require('request');
+
+test('should handle ENOTDIR as 404', function (t) {
+  t.plan(3);
+  var server = http.createServer(ecstatic(__dirname + '/public/subdir'));
+  t.on('end', function () { server.close() })
+  server.listen(0, function () {
+    var port = server.address().port;
+    request.get('http://localhost:' + port + '/index.html/hello', function (err, res, body) {
+      t.ifError(err);
+      t.equal(res.statusCode, 404);
+      t.equal(res.body, 'File not found. :(');
+    });
+  });
+});


### PR DESCRIPTION
This happens when you specify a file that exists and try and use that as a directory.

Eg. `something/index.html/folder` where index.html is a file. This PR changes ecstatic to treat the error as a 404.