### PR TITLE
Fixed double encoding in directory listings when directory name contains spaces

### DIFF
--- a/lib/ecstatic/showdir.js
+++ b/lib/ecstatic/showdir.js
@@ -120,9 +120,7 @@ module.exports = function (opts, stat) {
           var writeRow = function (file, i) {
             // render a row given a [name, stat] tuple
             var isDir = file[1].isDirectory && file[1].isDirectory();
-            var href = encodeURI(
-              parsed.pathname.replace(/\/$/, '') +
-              '/' + file[0]);
+            var href = parsed.pathname + encodeURI(file[0]);
 
             // append trailing slash and query for dir entry
             if (isDir) {

--- a/test/showdir-with-spaces.js
+++ b/test/showdir-with-spaces.js
@@ -7,7 +7,7 @@ var test = require('tap').test,
 var root = __dirname + '/public',
     baseDir = 'base';
 
-test('url encoding in href', function (t) {
+test('directory listing when directory name contains spaces', function (t) {
   var port = Math.floor(Math.random() * ((1<<16) - 1e4) + 1e4);
 
   var uri = 'http://localhost:' + port + path.join('/', baseDir, 'subdir_with%20space');

--- a/test/showdir-with-spaces.js
+++ b/test/showdir-with-spaces.js
@@ -1,0 +1,33 @@
+var test = require('tap').test,
+    ecstatic = require('../lib/ecstatic'),
+    http = require('http'),
+    request = require('request'),
+    path = require('path');
+
+var root = __dirname + '/public',
+    baseDir = 'base';
+
+test('url encoding in href', function (t) {
+  var port = Math.floor(Math.random() * ((1<<16) - 1e4) + 1e4);
+
+  var uri = 'http://localhost:' + port + path.join('/', baseDir, 'subdir_with%20space');
+
+  var server = http.createServer(
+    ecstatic({
+      root: root,
+      baseDir: baseDir,
+      showDir: true,
+      autoIndex: false
+    })
+  );
+
+  server.listen(port, function () {
+    request.get({
+      uri: uri
+    }, function(err, res, body) {
+      t.ok(/href="\/base\/subdir_with%20space\/index.html"/.test(body), 'We found the right href');
+      server.close();
+      t.end();
+    });
+  });
+});


### PR DESCRIPTION
If a directory listing was requested for a directory with spaces in its name, already escaped url was combined with the file names.

    Expected: subdir_with%20spaces\file_with%20space.html
    Got:      subdir_with%2520spaces\file_with%20space.html