### PR TITLE
Add ability to use multiple instances of ecstatic

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -76,26 +76,19 @@ var ecstatic = module.exports = function (dir, options) {
       fs.stat(file, function (err, stat) {
         if (err && (err.code === 'ENOENT' || err.code === 'ENOTDIR')) {
           if (req.statusCode == 404) {
-            console.log('allready 404 trying: ', req.url, req.statusCode, res.statusCode);
-            // This means we're already trying ./404.html and can not find it. So send plain text response with 404 status code
+            // This means we're already trying ./404.html and can not find it.
+            // So send plain text response with 404 status code
             status[404](res, next);
           }
           else if (!path.extname(parsed.pathname).length && defaultExt) {
-            console.log('default ext: ', req.url, req.statusCode, res.statusCode);
-            // If there is no file extension in the path and we have a default extension try filename and default extension combination
-            // Try that before rendering 404.html.
+            // If there is no file extension in the path and we have a default
+            // extension try filename and default extension combination before rendering 404.html.
             middleware({
-              url: parsed.pathname + '.' + defaultExt + ((parsed.search)? parsed.search:''),
-              statusCode: null
+              url: parsed.pathname + '.' + defaultExt + ((parsed.search)? parsed.search:'')
             }, res, next);
           }
           else {
             // Try to serve default ./404.html
-            console.log('404: ', req.url, req.statusCode, res.statusCode);
-            console.log({
-              url: (handleError ? ('/' + path.join(baseDir, '404.' + defaultExt)) : req.url),
-              statusCode: 404
-            });
             middleware({
               url: (handleError ? ('/' + path.join(baseDir, '404.' + defaultExt)) : req.url),
               statusCode: 404
@@ -138,7 +131,6 @@ var ecstatic = module.exports = function (dir, options) {
 
         }
         else {
-          // req.statusCode = 200;
           serve(stat);
         }
       });
@@ -222,8 +214,12 @@ var ecstatic = module.exports = function (dir, options) {
 
       res.setHeader('content-length', stat.size);
       res.setHeader('content-type', contentType);
-      console.log('serve: ' + res.statusCode, req.statusCode, req.method);
-      res.statusCode = req.statusCode || 200; // overridden for 404's
+
+      // set the response statusCode if we have a request statusCode.
+      // This only can happen if we have a 404 with some kind of 404.html
+      // In all other cases where we have a file we serve the 200
+      res.statusCode = req.statusCode || 200;
+
       if (req.method === "HEAD") {
         return res.end();
       }

--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -76,27 +76,26 @@ var ecstatic = module.exports = function (dir, options) {
       fs.stat(file, function (err, stat) {
         if (err && (err.code === 'ENOENT' || err.code === 'ENOTDIR')) {
           if (req.statusCode == 404) {
-            // This means we're already trying ./404.html
+            console.log('allready 404 trying: ', req.url, req.statusCode, res.statusCode);
+            // This means we're already trying ./404.html and can not find it. So send plain text response with 404 status code
             status[404](res, next);
           }
-          else if (defaultExt && !path.extname(parsed.pathname).length) {
-            //
-            // If no file extension is specified and there is a default extension
-            // try that before rendering 404.html.
-            //
+          else if (!path.extname(parsed.pathname).length && defaultExt) {
+            console.log('default ext: ', req.url, req.statusCode, res.statusCode);
+            // If there is no file extension in the path and we have a default extension try filename and default extension combination
+            // Try that before rendering 404.html.
             middleware({
-              url: parsed.pathname + '.' + defaultExt + ((parsed.search)? parsed.search:'')
+              url: parsed.pathname + '.' + defaultExt + ((parsed.search)? parsed.search:''),
+              statusCode: null
             }, res, next);
           }
           else {
-            // Try for ./404.html
-            //
-            // In order to make tests pass, we have to punch the status code
-            // in both spots. It's stupid and mysterious, but at least we get
-            // the behavior we want.
-            //
-            // TODO: Figure out what the Hell is going on and clean this up.
-            res.statusCode = 404;
+            // Try to serve default ./404.html
+            console.log('404: ', req.url, req.statusCode, res.statusCode);
+            console.log({
+              url: (handleError ? ('/' + path.join(baseDir, '404.' + defaultExt)) : req.url),
+              statusCode: 404
+            });
             middleware({
               url: (handleError ? ('/' + path.join(baseDir, '404.' + defaultExt)) : req.url),
               statusCode: 404
@@ -139,6 +138,7 @@ var ecstatic = module.exports = function (dir, options) {
 
         }
         else {
+          // req.statusCode = 200;
           serve(stat);
         }
       });
@@ -199,7 +199,7 @@ var ecstatic = module.exports = function (dir, options) {
           'Content-Range': 'bytes ' + start + '-' + end + '/' + total,
           'Accept-Ranges': 'bytes',
           'Content-Length': chunksize,
-          'Content-Type': contentType 
+          'Content-Type': contentType
         });
         fstream.pipe(res);
         return;
@@ -222,9 +222,9 @@ var ecstatic = module.exports = function (dir, options) {
 
       res.setHeader('content-length', stat.size);
       res.setHeader('content-type', contentType);
-
+      console.log('serve: ' + res.statusCode, req.statusCode, req.method);
+      res.statusCode = req.statusCode || 200; // overridden for 404's
       if (req.method === "HEAD") {
-        res.statusCode = req.statusCode || 200; // overridden for 404's
         return res.end();
       }
 

--- a/test/public/another-subdir/scripts.js
+++ b/test/public/another-subdir/scripts.js
@@ -1,0 +1,1 @@
+var foo = bar;

--- a/test/union-multiple-folders-cases.js
+++ b/test/union-multiple-folders-cases.js
@@ -1,0 +1,19 @@
+var fs = require('fs'),
+    path = require('path');
+
+module.exports = {
+  'index.html' : {
+    code : 200,
+    type : 'text/html',
+    body : 'index!!!\n',
+  },
+  'scripts.js' : {
+    code : 200,
+    type : 'application/javascript',
+    body : 'var foo = bar;\n',
+  }
+};
+
+if (require.main === module) {
+  console.log("ok 1 - test cases included");
+}

--- a/test/union-multiple-folders.js
+++ b/test/union-multiple-folders.js
@@ -1,0 +1,76 @@
+var test = require('tap').test,
+  ecstatic = require('../lib/ecstatic'),
+  union = require('union'),
+  request = require('request'),
+  mkdirp = require('mkdirp'),
+  fs = require('fs'),
+  path = require('path');
+
+var subdir = __dirname + '/public/subdir',
+  anotherSubdir = __dirname + '/public/another-subdir',
+  baseDir = 'base';
+
+mkdirp.sync(root + '/emptyDir');
+
+var cases = require('./union-multiple-folders-cases');
+
+test('union', function(t) {
+  var filenames = Object.keys(cases);
+  var port = Math.floor(Math.random() * ((1 << 16) - 1e4) + 1e4);
+
+  var server = union.createServer({
+    before: [
+      ecstatic({
+        root: subdir,
+        gzip: true,
+        baseDir: baseDir,
+        autoIndex: true,
+        showDir: true,
+        defaultExt: 'html',
+        handleError: true
+      }), ecstatic({
+        root: anotherSubdir,
+        gzip: true,
+        baseDir: baseDir,
+        autoIndex: true,
+        showDir: true,
+        defaultExt: 'html',
+        handleError: true
+      })
+    ]
+  });
+
+  server.listen(port, function() {
+    var pending = filenames.length;
+    filenames.forEach(function(file) {
+      var uri = 'http://localhost:' + port + path.join('/', baseDir, file),
+        headers = cases[file].headers || {};
+
+      request.get({
+        uri: uri,
+        followRedirect: false,
+        headers: headers
+      }, function(err, res, body) {
+        if (err) t.fail(err);
+        var r = cases[file];
+        t.equal(res.statusCode, r.code, 'status code for `' + file + '`');
+
+        if (r.type !== undefined) {
+          t.equal(
+            res.headers['content-type'].split(';')[0], r.type,
+            'content-type for `' + file + '`'
+          );
+        }
+
+        if (r.body !== undefined) {
+          t.equal(body, r.body, 'body for `' + file + '`');
+        }
+
+        if (--pending === 0) {
+          server.close();
+          t.end();
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
And fixes weird issue with 404 status code.

The `res.statusCode` should always be check and adjusted in the `serve` method. Just set the `req.statusCode` in `statFile` and use it in `serve`.

Hope this makes sense. I added tests for multiple folder to serve. All test seem to work correctly.

Closes #136 