### PR TITLE
destroy the file stream if the response closes

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -187,6 +187,9 @@ var ecstatic = module.exports = function (dir, options) {
         fstream.on('error', function (err) {
           status['500'](res, next, { error: err });
         });
+        res.on('close', function () {
+           fstream.destroy(); 
+        });
         res.writeHead(206, {
           'Content-Range': 'bytes ' + start + '-' + end + '/' + total,
           'Accept-Ranges': 'bytes',


### PR DESCRIPTION
`src.pipe(dst)` doesn't close the source stream if the destination closes. this means that ecstatic will leaks file descriptors if the response closes before the file stream ends