### PR TITLE
correct sort ordering and also applied to dirs and lolwuts

### DIFF
--- a/lib/ecstatic/showdir.js
+++ b/lib/ecstatic/showdir.js
@@ -139,9 +139,9 @@ module.exports = function (opts, stat) {
               '</tr>\n';
           };
 
-          dirs.sort(function (a, b) { return b[0] - a[0]; }).forEach(writeRow);
-          files.sort(function (a, b) { return b.toString().localeCompare(a.toString()); }).forEach(writeRow);
-          lolwuts.sort(function (a, b) { return b[0] - a[0] }).forEach(writeRow);
+          dirs.sort(function (a, b) { return a[0].toString().localeCompare(b[0].toString()); }).forEach(writeRow);
+          files.sort(function (a, b) { return a.toString().localeCompare(b.toString()); }).forEach(writeRow);
+          lolwuts.sort(function (a, b) { return a[0].toString().localeCompare(b[0].toString()); }).forEach(writeRow);
 
           html += '</table>\n';
           html += '<br><address>Node.js ' +


### PR DESCRIPTION
- b[0]-a[0] returns NaN, so this is never valid in a sorting function
- reverted sorting order a-z (was z-a)