### PR TITLE
added fallback to process.env.PORT

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -282,7 +282,7 @@ function decodePathname(pathname) {
 if (!module.parent) {
   var http = require('http'),
       opts = require('minimist')(process.argv.slice(2)),
-      envPORT = process.env.PORT,
+      envPORT = parseInt(process.env.PORT, 10),
       port = envPORT > 1024 && envPORT <= 65536 ? envPORT : opts.port || opts.p || 8000,
       dir = opts.root || opts._[0] || process.cwd();
 

--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -282,7 +282,8 @@ function decodePathname(pathname) {
 if (!module.parent) {
   var http = require('http'),
       opts = require('minimist')(process.argv.slice(2)),
-      port = opts.port || opts.p || 8000,
+      envPORT = process.env.PORT,
+      port = envPORT > 1024 && envPORT <= 65536 ? envPORT : opts.port || opts.p || 8000,
       dir = opts.root || opts._[0] || process.cwd();
 
   if (opts.help || opts.h) {

--- a/test/process-env-port.js
+++ b/test/process-env-port.js
@@ -1,0 +1,48 @@
+var test = require('tap').test,
+    ecstatic = require('../lib/ecstatic'),
+    spawn = require('child_process').spawn
+
+test('sane port', function (t) {
+  t.plan(2)
+  process.env.PORT = getRandomInt(1025, 65536)
+  var ecstatic = spawn(process.execPath, [__dirname + '/../lib/ecstatic.js'])
+  ecstatic.stdout.on('data', function (data) {
+    t.pass('ecstatic should be started')
+    var curl = spawn('curl', ['http://0.0.0.0:' + process.env.PORT])
+    curl.stdout.on('error', function (err) {
+      console.error(err)
+      t.fail('curl did not get back a response from the server')
+    })
+    curl.stdout.on('end', function () {
+      t.pass('curl should get a response from the server')
+      curl.kill('SIGINT')
+      ecstatic.kill('SIGINT')
+    })
+  })
+})
+
+test('insane ports', function (t) {
+  var insanePorts = [ -Infinity, 1023, 9090.8, 65537, Infinity, 'wow', null, undefined]
+  insanePorts.forEach(function (port) {
+    process.env.PORT = port
+    var ecstatic = spawn(process.execPath, [__dirname + '/../lib/ecstatic.js'])
+    ecstatic.stdout.on('data', function (data) {
+      t.pass('ecstatic should be started')
+      var curl = spawn('curl', ['http://0.0.0.0:8080'])
+      curl.stdout.on('error', function (err) {
+        console.error(err)
+        t.fail('curl did not get back a response from the server')
+      })
+      curl.stdout.on('end', function () {
+        t.pass('curl should get a response from the server on port 8080')
+        if (port === insanePorts[insanePorts.length - 1]) t.end()
+        curl.kill('SIGINT')
+        ecstatic.kill('SIGINT')
+      })
+    })
+  })
+})
+
+function getRandomInt (min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min
+}

--- a/test/process-env-port.js
+++ b/test/process-env-port.js
@@ -1,23 +1,30 @@
 var test = require('tap').test,
     request = require('request'),
     spawn = require('child_process').spawn,
-    insanePorts = [ -Infinity, 1023, 65537, Infinity, 'wow', null, undefined]
+    sanePort = getRandomInt(1025, 65536),
+    insanePorts = [-Infinity, 1023, 65537, Infinity, 'wow', null, undefined]
 
 test('sane port', function (t) {
   t.plan(2)
-  process.env.PORT = getRandomInt(1025, 65536)
-  var ecstatic = spawn(process.execPath, [__dirname + '/../lib/ecstatic.js'])
+  var ecstatic = spawn(process.execPath, [__dirname + '/../lib/ecstatic.js'], {
+    env: {
+      PORT: sanePort
+    }
+  })
   ecstatic.stdout.on('data', function (data) {
     t.pass('ecstatic should be started')
-    checkServerIsRunning('http://0.0.0.0:' + process.env.PORT, ecstatic, t)
+    checkServerIsRunning('http://0.0.0.0:' + sanePort, ecstatic, t)
   })
 })
 
 insanePorts.forEach(function (port) {
   test('insane port: ' + port, function (t) {
     t.plan(2)
-    process.env.PORT = port
-    var ecstatic = spawn(process.execPath, [__dirname + '/../lib/ecstatic.js'])
+    var ecstatic = spawn(process.execPath, [__dirname + '/../lib/ecstatic.js'], {
+      env: {
+        PORT: port
+      }
+    })
     ecstatic.stdout.on('data', function (data) {
       t.pass('ecstatic should be started')
       checkServerIsRunning('http://0.0.0.0:8000', ecstatic, t)

--- a/test/process-env-port.js
+++ b/test/process-env-port.js
@@ -2,6 +2,7 @@ var test = require('tap').test,
     request = require('request'),
     spawn = require('child_process').spawn,
     sanePort = getRandomInt(1025, 65536),
+    floatingPointPort = 9090.86,
     insanePorts = [-Infinity, 1023, 65537, Infinity, 'wow', null, undefined]
 
 test('sane port', function (t) {
@@ -14,6 +15,19 @@ test('sane port', function (t) {
   ecstatic.stdout.on('data', function (data) {
     t.pass('ecstatic should be started')
     checkServerIsRunning('http://0.0.0.0:' + sanePort, ecstatic, t)
+  })
+})
+
+test('floating point port', function (t) {
+  t.plan(2)
+  var ecstatic = spawn(process.execPath, [__dirname + '/../lib/ecstatic.js'], {
+    env: {
+      PORT: floatingPointPort
+    }
+  })
+  ecstatic.stdout.on('data', function (data) {
+    t.pass('ecstatic should be started')
+    checkServerIsRunning('http://0.0.0.0:9090', ecstatic, t)
   })
 })
 

--- a/test/process-env-port.js
+++ b/test/process-env-port.js
@@ -15,7 +15,7 @@ test('floating point port', function (t) {
 
 insanePorts.forEach(function (port) {
   test('insane port: ' + port, function (t) {
-    startServer('http://0.0.0.0:9090', floatingPointPort, t)
+    startServer('http://0.0.0.0:8000', port, t)
   })
 })
 

--- a/test/process-env-port.js
+++ b/test/process-env-port.js
@@ -6,43 +6,16 @@ var test = require('tap').test,
     insanePorts = [-Infinity, 1023, 65537, Infinity, 'wow', null, undefined]
 
 test('sane port', function (t) {
-  t.plan(2)
-  var ecstatic = spawn(process.execPath, [__dirname + '/../lib/ecstatic.js'], {
-    env: {
-      PORT: sanePort
-    }
-  })
-  ecstatic.stdout.on('data', function (data) {
-    t.pass('ecstatic should be started')
-    checkServerIsRunning('http://0.0.0.0:' + sanePort, ecstatic, t)
-  })
+  startServer('http://0.0.0.0:' + sanePort, sanePort, t)
 })
 
 test('floating point port', function (t) {
-  t.plan(2)
-  var ecstatic = spawn(process.execPath, [__dirname + '/../lib/ecstatic.js'], {
-    env: {
-      PORT: floatingPointPort
-    }
-  })
-  ecstatic.stdout.on('data', function (data) {
-    t.pass('ecstatic should be started')
-    checkServerIsRunning('http://0.0.0.0:9090', ecstatic, t)
-  })
+  startServer('http://0.0.0.0:9090', floatingPointPort, t)
 })
 
 insanePorts.forEach(function (port) {
   test('insane port: ' + port, function (t) {
-    t.plan(2)
-    var ecstatic = spawn(process.execPath, [__dirname + '/../lib/ecstatic.js'], {
-      env: {
-        PORT: port
-      }
-    })
-    ecstatic.stdout.on('data', function (data) {
-      t.pass('ecstatic should be started')
-      checkServerIsRunning('http://0.0.0.0:8000', ecstatic, t)
-    })
+    startServer('http://0.0.0.0:9090', floatingPointPort, t)
   })
 })
 
@@ -58,5 +31,18 @@ function checkServerIsRunning (url, ps, t) {
     } else {
       t.fail('the server could not be reached')
     }
+  })
+}
+
+function startServer (url, port, t) {
+  t.plan(2)
+  var ecstatic = spawn(process.execPath, [__dirname + '/../lib/ecstatic.js'], {
+    env: {
+      PORT: port
+    }
+  })
+  ecstatic.stdout.on('data', function (data) {
+    t.pass('ecstatic should be started')
+    checkServerIsRunning(url, ecstatic, t)
   })
 }


### PR DESCRIPTION
As mentioned in #119, this allows the server to listen to the port given in process.env.PORT if the number is of sane value.
If no value is given in process.env.PORT or the port number is _not_ sane then the server listens on
``` opts.port || opts.p || 8000``` as usual.

*I chose sanity to be ports >1024 and =< 65536 based off [this list of well-know ports](http://www.webopedia.com/quick_ref/portnumbers.asp)

I wasn't really sure how to write test for this.  It seemed like an easy change but if test are needed I could see what I can do.