### PR TITLE
-H/--header like curl

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -310,7 +310,7 @@ function decodePathname(pathname) {
 
 if (!module.parent) {
   var http = require('http'),
-      opts = require('minimist')(process.argv.slice(2)),
+      opts = require('minimist')(process.argv.slice(2), { alias: { H: 'header' } }),
       envPORT = parseInt(process.env.PORT, 10),
       port = envPORT > 1024 && envPORT <= 65536 ? envPORT : opts.port || opts.p || 8000,
       dir = opts.root || opts._[0] || process.cwd();
@@ -322,7 +322,16 @@ if (!module.parent) {
     return;
   }
 
-  http.createServer(ecstatic(dir, opts))
+  var st = ecstatic(dir, opts)
+  http.createServer(function (req, res) {
+    [].concat(opts.header || []).forEach(function (h) {
+      var m = /([^:]+)\s*:\s*(.*)/.exec(h),
+          key = m ? m[1] : h
+          value = m ? m[2] : true;
+      res.setHeader(key, value);
+    })
+    st(req, res)
+  })
     .listen(port, function () {
       console.log('ecstatic serving ' + dir + ' at http://0.0.0.0:' + port);
     });


### PR DESCRIPTION
This patch adds `-H` to the `ecstatic` command, so if you want to send a CORS header on every request, you could for example do:

```
ecstatic -p 8001 . -H 'Access-Control-Allow-Origin: *'
```