### PR TITLE
Use encodeuricomponent

### DIFF
--- a/lib/ecstatic/showdir.js
+++ b/lib/ecstatic/showdir.js
@@ -121,7 +121,7 @@ module.exports = function (opts, stat) {
           var writeRow = function (file, i) {
             // render a row given a [name, stat] tuple
             var isDir = file[1].isDirectory && file[1].isDirectory();
-            var href = parsed.pathname.replace(/\/$/, '') + '/' + encodeURI(file[0]);
+            var href = parsed.pathname.replace(/\/$/, '') + '/' + encodeURIComponent(file[0]);
 
             // append trailing slash and query for dir entry
             if (isDir) {

--- a/test/showdir-href-encoding.js
+++ b/test/showdir-href-encoding.js
@@ -25,7 +25,7 @@ test('url encoding in href', function (t) {
     request.get({
       uri: uri
     }, function(err, res, body) {
-      t.match(body, /href="\/base\/show\-dir\-href\-encoding\/aname\+aplus\.txt"/, 'We found the right href');
+      t.match(body, /href="\/base\/show\-dir\-href\-encoding\/aname%2Baplus\.txt"/, 'We found the right href');
       server.close();
       t.end();
     });


### PR DESCRIPTION
I happened to have a file with a '#' in the filename, and when using @indexzero's http-server (which uses ecstatic for autoIndex) the filename wasn't being properly encoded. This should fix that (as well as any files which use "; , / ? : @ & = + $" in the filename as well). Also updated a test that broke with the change.