### PR TITLE
opts.headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ var opts = {
              showDir       : true,
              autoIndex     : false,
              humanReadable : true,
+             headers       : {},
              si            : false,
              defaultExt    : 'html',
              gzip          : false,
@@ -105,6 +106,19 @@ Turn **off** directory listings with `opts.showDir === false`. Defaults to **tru
 
 If showDir is enabled, add human-readable file sizes. Defaults to **true**.
 Aliases are `humanreadable` and `human-readable`.
+
+### `opts.headers`
+
+Set headers on every response. `opts.headers` can be an object mapping string
+header names to string header values, a colon (:) separated string, or an array
+of colon separated strings.
+
+`opts.H` and `opts.header` are aliased to `opts.headers` so that you can use
+`-H` and `--header` options to set headers on the command-line like curl:
+
+``` sh
+$ ecstatic ./public -p 5000 -H 'Access-Control-Allow-Origin: *'
+```
 
 ### `opts.si`
 

--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -26,6 +26,7 @@ var ecstatic = module.exports = function (dir, options) {
       baseDir = opts.baseDir,
       defaultExt = opts.defaultExt,
       handleError = opts.handleError,
+      headers = opts.headers,
       serverHeader = opts.serverHeader,
       weakEtags = opts.weakEtags;
 
@@ -73,6 +74,9 @@ var ecstatic = module.exports = function (dir, options) {
       // Set common headers.
       res.setHeader('server', 'ecstatic-'+version);
     }
+    Object.keys(headers).forEach(function (key) {
+      res.setHeader(key, headers[key])
+    })
 
     // TODO: This check is broken, which causes the 403 on the
     // expected 404.
@@ -80,6 +84,9 @@ var ecstatic = module.exports = function (dir, options) {
       return status[403](res, next);
     }
 
+    if (req.method === 'OPTIONS') {
+      return res.end()
+    }
     if (req.method && (req.method !== 'GET' && req.method !== 'HEAD' )) {
       return status[405](res, next);
     }

--- a/lib/ecstatic/opts.js
+++ b/lib/ecstatic/opts.js
@@ -10,6 +10,7 @@ module.exports = function (opts) {
       gzip = false,
       defaultExt = '.html',
       handleError = true,
+      headers = {},
       serverHeader = true,
       contentType = 'application/octet-stream',
       mimeTypes,
@@ -90,6 +91,29 @@ module.exports = function (opts) {
     });
 
     [
+      'H',
+      'header',
+      'headers'
+    ].forEach(function (k) {
+      if (!isDeclared(k)) return;
+      if (Array.isArray(opts[k])) {
+        opts[k].forEach(setHeader);
+      }
+      else if (opts[k] && typeof opts[k] === 'object') {
+        Object.keys(opts[k]).forEach(function (key) {
+          headers[key] = opts[k][key];
+        });
+      }
+      else setHeader(opts[k]);
+
+      function setHeader (str) {
+        var m = /^(.+?)\s*:\s*(.*)$/.exec(str)
+        if (!m) headers[str] = true
+        else headers[m[1]] = m[2]
+      }
+    });
+
+    [
       'serverHeader',
       'serverheader',
       'server-header'
@@ -161,6 +185,7 @@ module.exports = function (opts) {
     baseDir: (opts && opts.baseDir) || '/',
     gzip: gzip,
     handleError: handleError,
+    headers: headers,
     serverHeader: serverHeader,
     contentType: contentType,
     mimeTypes: mimeTypes,

--- a/test/headers.js
+++ b/test/headers.js
@@ -1,0 +1,121 @@
+var test = require('tap').test,
+    ecstatic = require('../lib/ecstatic'),
+    http = require('http'),
+    request = require('request');
+
+var root = __dirname + '/public',
+    baseDir = 'base';
+
+test('headers object', function (t) {
+  t.plan(4);
+
+  var server = http.createServer(
+    ecstatic({
+      root: root,
+      headers: {
+        Wow: 'sweet',
+        Cool: 'beans'
+      },
+      autoIndex: true,
+      defaultExt: 'html'
+    })
+  );
+
+  server.listen(function () {
+    var port = server.address().port,
+        uri = 'http://localhost:' + port + '/subdir';
+    request.get({ uri: uri }, function (err, res, body) {
+      t.ifError(err);
+      t.equal(res.statusCode, 200)
+      t.equal(res.headers.wow, 'sweet')
+      t.equal(res.headers.cool, 'beans')
+    });
+  });
+  t.once('end', function () {
+    server.close();
+  });
+});
+
+test('header string', function (t) {
+  t.plan(3);
+
+  var server = http.createServer(
+    ecstatic({
+      root: root,
+      header: 'beep: boop', // for command-line --header 'beep: boop'
+      autoIndex: true,
+      defaultExt: 'html'
+    })
+  );
+
+  server.listen(function () {
+    var port = server.address().port,
+        uri = 'http://localhost:' + port + '/subdir';
+    request.get({ uri: uri }, function (err, res, body) {
+      t.ifError(err);
+      t.equal(res.statusCode, 200)
+      t.equal(res.headers.beep, 'boop')
+    });
+  });
+  t.once('end', function () {
+    server.close();
+  });
+});
+
+test('header array', function (t) {
+  t.plan(3);
+
+  var server = http.createServer(
+    ecstatic({
+      root: root,
+      header: [
+        'beep: boop', // --header 'beep: boop'
+        'what: ever' // --header 'what: ever'
+      ],
+      autoIndex: true,
+      defaultExt: 'html'
+    })
+  );
+
+  server.listen(function () {
+    var port = server.address().port,
+        uri = 'http://localhost:' + port + '/subdir';
+    request.get({ uri: uri }, function (err, res, body) {
+      t.ifError(err);
+      t.equal(res.statusCode, 200)
+      t.equal(res.headers.beep, 'boop')
+    });
+  });
+  t.once('end', function () {
+    server.close();
+  });
+});
+
+test('H array', function (t) {
+  t.plan(3);
+
+  var server = http.createServer(
+    ecstatic({
+      root: root,
+      H: [
+        'beep: boop', // -H 'beep: boop'
+        'what: ever' // -H 'what: ever'
+      ],
+      autoIndex: true,
+      defaultExt: 'html'
+    })
+  );
+
+  server.listen(function () {
+    var port = server.address().port,
+        uri = 'http://localhost:' + port + '/subdir';
+    request.get({ uri: uri }, function (err, res, body) {
+      t.ifError(err);
+      t.equal(res.statusCode, 200)
+      t.equal(res.headers.beep, 'boop')
+    });
+  });
+  t.once('end', function () {
+    server.close();
+  });
+});


### PR DESCRIPTION
This patch implements curl-like `-H`/`--header` like functionality using `opts.H`/`opts.header`/`opts.headers` for parity between the command-line tool and the API.

This patch replaces #153.