### PR TITLE
boolean options

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -319,7 +319,20 @@ function decodePathname(pathname) {
 
 if (!module.parent) {
   var http = require('http'),
-      opts = require('minimist')(process.argv.slice(2)),
+      opts = require('minimist')(process.argv.slice(2), {
+        boolean: [
+          'showdir', 'showDir',
+          'humanreadable', 'humanReadable', 'human-readable',
+          'si', 'index',
+          'handleError', 'handleerror',
+          'cors', 'CORS',
+          'gzip',
+          'serverHeader', 'serverheader', 'server-header',
+          'weakEtags', 'weaketags', 'weak-etags',
+          'weakcompare', 'weakCompare', 'weak-compare', 'weak-Compare',
+          'handleOptionsMethod', 'handleoptionsmethod', 'handle-options-method'
+        ]
+      }),
       envPORT = parseInt(process.env.PORT, 10),
       port = envPORT > 1024 && envPORT <= 65536 ? envPORT : opts.port || opts.p || 8000,
       dir = opts.root || opts._[0] || process.cwd();


### PR DESCRIPTION
Currently:

```
$ ecstatic --cors public -p 8000
```

will serve `./`, NOT `./public` because `--cors` gobbles up the `public` argument. With this patch, the above works as expected.