### PR TITLE
more boolean handling

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -318,11 +318,11 @@ function decodePathname(pathname) {
 }
 
 if (!module.parent) {
-  var defaults = require('./defaults.js')
+  var defaults = require('./ecstatic/defaults.json')
   var http = require('http'),
       opts = require('minimist')(process.argv.slice(2), {
-        alias: require('./aliases.json'),
-        default: require('./defaults.json'),
+        alias: require('./ecstatic/aliases.json'),
+        default: defaults,
         boolean: Object.keys(defaults).filter(function (key) {
           return typeof defaults[key] === 'boolean'
         })

--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -318,20 +318,14 @@ function decodePathname(pathname) {
 }
 
 if (!module.parent) {
+  var defaults = require('./defaults.js')
   var http = require('http'),
       opts = require('minimist')(process.argv.slice(2), {
-        boolean: [
-          'showdir', 'showDir',
-          'humanreadable', 'humanReadable', 'human-readable',
-          'si', 'index',
-          'handleError', 'handleerror',
-          'cors', 'CORS',
-          'gzip',
-          'serverHeader', 'serverheader', 'server-header',
-          'weakEtags', 'weaketags', 'weak-etags',
-          'weakcompare', 'weakCompare', 'weak-compare', 'weak-Compare',
-          'handleOptionsMethod', 'handleoptionsmethod', 'handle-options-method'
-        ]
+        alias: require('./aliases.json'),
+        default: require('./defaults.json'),
+        boolean: Object.keys(defaults).filter(function (key) {
+          return typeof defaults[key] === 'boolean'
+        })
       }),
       envPORT = parseInt(process.env.PORT, 10),
       port = envPORT > 1024 && envPORT <= 65536 ? envPORT : opts.port || opts.p || 8000,

--- a/lib/ecstatic/aliases.json
+++ b/lib/ecstatic/aliases.json
@@ -1,0 +1,33 @@
+{
+  "autoIndex": [ "autoIndex", "autoindex" ],
+  "showDir": [ "showDir", "showdir" ],
+  "humanReadable": [ "humanReadable", "humanreadable", "human-readable" ],
+  "si": [ "si", "index" ],
+  "handleError": [ "handleError", "handleerror" ],
+  "cors": [ "cors", "CORS" ],
+  "headers": [ "H", "header", "headers" ],
+  "serverHeader": [ "serverHeader", "serverheader", "server-header" ],
+  "contentType": [ "contentType", "contenttype", "content-type" ],
+  "mimeType": [
+    "mimetype",
+    "mimetypes",
+    "mimeType",
+    "mimeTypes",
+    "mime-type",
+    "mime-types",
+    "mime-Type",
+    "mime-Types"
+  ],
+  "weakEtags": [ "weakEtags", "weaketags", "weak-etags" ],
+  "weakCompare": [
+    "weakcompare",
+    "weakCompare",
+    "weak-compare",
+    "weak-Compare"
+  ],
+  "handleOptionsMethod": [
+    "handleOptionsMethod",
+    "handleoptionsmethod",
+    "handle-options-method"
+  ]
+}

--- a/lib/ecstatic/defaults.json
+++ b/lib/ecstatic/defaults.json
@@ -1,0 +1,15 @@
+{
+  "autoIndex": true,
+  "showDir": true,
+  "humanReadable": true,
+  "si": false,
+  "cache": "max-age=3600",
+  "gzip": false,
+  "defaultExt": ".html",
+  "handleError": true,
+  "serverHeader": true,
+  "contentType": "application/octet-stream",
+  "weakEtags": false,
+  "weakCompare": false,
+  "handleOptionsMethod": false
+}

--- a/lib/ecstatic/opts.js
+++ b/lib/ecstatic/opts.js
@@ -141,7 +141,7 @@ module.exports = function (opts) {
 
     aliases.handleOptionsMethod.some(function (k) {
       if (isDeclared(k)) {
-        handleOptionsMethod = opts[k];
+        handleOptionsMethod = handleOptionsMethod || opts[k];
         return true;
       }
     });

--- a/lib/ecstatic/opts.js
+++ b/lib/ecstatic/opts.js
@@ -1,63 +1,52 @@
 // This is so you can have options aliasing and defaults in one place.
 
-module.exports = function (opts) {
+var defaults = require('./defaults.json');
+var aliases = require('./aliases.json')
 
-  var autoIndex = true,
-      showDir = true,
-      humanReadable = true,
-      si = false,
-      cache = 'max-age=3600',
-      gzip = false,
-      defaultExt = '.html',
-      handleError = true,
+module.exports = function (opts) {
+  var autoIndex = defaults.autoIndex,
+      showDir = defaults.showDir,
+      humanReadable = defaults.humanReadable,
+      si = defaults.si,
+      cache = defaults.cache,
+      gzip = defaults.gzip,
+      defaultExt = defaults.defaultExt,
+      handleError = defaults.handleError,
       headers = {},
-      serverHeader = true,
-      contentType = 'application/octet-stream',
+      serverHeader = defaults.serverHeader,
+      contentType = defaults.contentType,
       mimeTypes,
-      weakEtags = false,
-      weakCompare = false,
-      handleOptionsMethod = false;
+      weakEtags = defaults.weakEtags,
+      weakCompare = defaults.weakCompare,
+      handleOptionsMethod = defaults.handleOptionsMethod;
 
   function isDeclared(k) {
     return typeof opts[k] !== 'undefined' && opts[k] !== null;
   }
 
   if (opts) {
-    [
-      'autoIndex',
-      'autoindex'
-    ].some(function (k) {
+    aliases.autoIndex.some(function (k) {
       if (isDeclared(k)) {
         autoIndex = opts[k];
         return true;
       }
     });
 
-    [
-      'showDir',
-      'showdir'
-    ].some(function (k) {
+    aliases.showDir.some(function (k) {
       if (isDeclared(k)) {
         showDir = opts[k];
         return true;
       }
     });
 
-    [
-      'humanReadable',
-      'humanreadable',
-      'human-readable'
-    ].some(function (k) {
+    aliases.humanReadable.some(function (k) {
       if (isDeclared(k)) {
         humanReadable = opts[k];
         return true;
       }
     });
 
-    [
-      'si',
-      'index'
-    ].some(function (k) {
+    aliases.si.some(function (k) {
       if (isDeclared(k)) {
         si = opts[k];
         return true;
@@ -81,20 +70,14 @@ module.exports = function (opts) {
       gzip = opts.gzip;
     }
 
-    [
-      'handleError',
-      'handleerror'
-    ].some(function (k) {
+    aliases.handleError.some(function (k) {
       if (isDeclared(k)) {
         handleError = opts[k];
         return true;
       }
     });
 
-    [
-      'cors',
-      'CORS'
-    ].forEach(function(k) {
+    aliases.cors.forEach(function(k) {
       if (isDeclared(k) && k) {
         handleOptionsMethod = true;
         headers['Access-Control-Allow-Origin'] = '*';
@@ -102,11 +85,7 @@ module.exports = function (opts) {
       }
     });
 
-    [
-      'H',
-      'header',
-      'headers'
-    ].forEach(function (k) {
+    aliases.headers.forEach(function (k) {
       if (!isDeclared(k)) return;
       if (Array.isArray(opts[k])) {
         opts[k].forEach(setHeader);
@@ -125,72 +104,42 @@ module.exports = function (opts) {
       }
     });
 
-    [
-      'serverHeader',
-      'serverheader',
-      'server-header'
-    ].some(function (k) {
+    aliases.serverHeader.some(function (k) {
       if (isDeclared(k)) {
         serverHeader = opts[k];
         return true;
       }
     });
 
-    [
-      'contentType',
-      'contenttype',
-      'content-type'
-    ].some(function (k) {
+    aliases.contentType.some(function (k) {
       if (isDeclared(k)) {
         contentType = opts[k];
         return true;
       }
     });
 
-    [
-      'mimetype',
-      'mimetypes',
-      'mimeType',
-      'mimeTypes',
-      'mime-type',
-      'mime-types',
-      'mime-Type',
-      'mime-Types'
-    ].some(function (k) {
+    aliases.mimeType.some(function (k) {
       if (isDeclared(k)) {
         mimeTypes = opts[k];
         return true;
       }
     });
 
-    [
-      'weakEtags',
-      'weaketags',
-      'weak-etags'
-    ].some(function (k) {
+    aliases.weakEtags.some(function (k) {
       if (isDeclared(k)) {
         weakEtags = opts[k];
         return true;
       }
     });
 
-    [
-      'weakcompare',
-      'weakCompare',
-      'weak-compare',
-      'weak-Compare',
-    ].some(function (k) {
+    aliases.weakCompare.some(function (k) {
       if (isDeclared(k)) {
         weakCompare = opts[k];
         return true;
       }
     });
 
-    [
-      'handleOptionsMethod',
-      'handleoptionsmethod',
-      'handle-options-method'
-    ].some(function (k) {
+    aliases.handleOptionsMethod.some(function (k) {
       if (isDeclared(k)) {
         handleOptionsMethod = opts[k];
         return true;


### PR DESCRIPTION
On the back of #160, this patch fixes an issue where setting an option as boolean sets the value to `false` unless otherwise specified in minimist. I've factored the defaults from opts.js into defaults.json so they can be shared from opts.js and the bin script and also the aliases. Before the handleOptionsMethod was set to `false` even when `--cors` was turned on because of the boolean setting.