### PR TITLE
set cors to false to enable booleanism on the command-line

### DIFF
--- a/lib/ecstatic/defaults.json
+++ b/lib/ecstatic/defaults.json
@@ -4,6 +4,7 @@
   "humanReadable": true,
   "si": false,
   "cache": "max-age=3600",
+  "cors": false,
   "gzip": false,
   "defaultExt": ".html",
   "handleError": true,


### PR DESCRIPTION
I missed `cors` in the default list, which was the whole reason behind the first patch!

With this patch:

```
$ ecstatic --cors public/ -p 8000
```

will finally work.