### PR TITLE
Allow using a function to set cache-control headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ var opts = {
 If `opts` is a string, the string is assigned to the root folder and all other
 options are set to their defaults.
 
-### `opts.root` 
+### `opts.root`
 
 `opts.root` is the directory you want to serve up.
 
@@ -98,6 +98,8 @@ resolve to `./public/index.html`.
 
 Customize cache control with `opts.cache` , if it is a number then it will set max-age in seconds.
 Other wise it will pass through directly to cache-control. Time defaults to 3600 s (ie, 1 hour).
+
+If it is a function, it will be executed on every request, and passed the pathname.  Whatever it returns, string or number, will be used as the cache control header like above.
 
 ### `opts.showDir`
 
@@ -160,7 +162,7 @@ Defaults to **application/octet-stream**.
 
 Add new or override one or more mime-types. This affects the HTTP Content-Type header.
 Can either be a path to a [`.types`](http://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types) file or an object hash of type(s).
-    
+
     ecstatic({ mimeType: { 'mime-type': ['file_extension', 'file_extension'] } })
 
 ### `opts.handleError`

--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -224,7 +224,17 @@ var ecstatic = module.exports = function (dir, options) {
       // TODO: Helper for this, with default headers.
       res.setHeader('etag', etag(stat, weakEtags));
       res.setHeader('last-modified', (new Date(stat.mtime)).toUTCString());
-      res.setHeader('cache-control', cache);
+
+      if (typeof cache === 'function') {
+        var requestSpecificCache = cache(pathname)
+        if (typeof requestSpecificCache === 'number') {
+          requestSpecificCache = 'max-age=' + requestSpecificCache;
+        }
+        res.setHeader('cache-control', requestSpecificCache);
+      } else {
+        res.setHeader('cache-control', cache);
+      }
+
 
       // Return a 304 if necessary
       if (shouldReturn304(req, stat)) {
@@ -273,7 +283,7 @@ var ecstatic = module.exports = function (dir, options) {
       }
 
       if (clientEtag) {
-        if (opts.weakCompare && clientEtag !== serverEtag 
+        if (opts.weakCompare && clientEtag !== serverEtag
           && clientEtag !== ('W/' + serverEtag) && ('W/' + clientEtag) !== serverEtag) {
           return false;
         } else if (!opts.weakCompare && (clientEtag !== serverEtag || clientEtag.indexOf('W/') === 0)) {

--- a/lib/ecstatic/opts.js
+++ b/lib/ecstatic/opts.js
@@ -61,8 +61,11 @@ module.exports = function (opts) {
       if (typeof opts.cache === 'string') {
         cache = opts.cache;
       }
-      else if(typeof opts.cache === 'number') {
+      else if (typeof opts.cache === 'number') {
         cache = 'max-age=' + opts.cache;
+      }
+      else if (typeof opts.cache === 'function') {
+        cache = opts.cache
       }
     }
 

--- a/test/cache.js
+++ b/test/cache.js
@@ -74,19 +74,14 @@ test('custom cache-content function returning a number', function(t) {
       t.ifError(err);
       t.equal(res.statusCode, 200, 'a.txt should be found');
       t.equal(res.headers['cache-control'], 'max-age=1');
-      server.close(function() {
 
-        server.listen(0, function() {
-          var port = server.address().port;
-          request.get('http://localhost:' + port + '/a.txt', function(err, res, body) {
-            t.ifError(err);
-            t.equal(res.statusCode, 200, 'a.txt should be found');
-            t.equal(res.headers['cache-control'], 'max-age=2');
-            server.close(function() { t.end(); });
-          });
-        });
-
+      request.get('http://localhost:' + port + '/a.txt', function(err, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200, 'a.txt should be found');
+        t.equal(res.headers['cache-control'], 'max-age=2');
+        server.close(function() { t.end(); });
       });
+
     });
   });
 });
@@ -114,19 +109,14 @@ test('custom cache-content function returning a string', function(t) {
       t.ifError(err);
       t.equal(res.statusCode, 200, 'a.txt should be found');
       t.equal(res.headers['cache-control'], 'max-meh=1');
-      server.close(function() {
 
-        server.listen(0, function() {
-          var port = server.address().port;
-          request.get('http://localhost:' + port + '/a.txt', function(err, res, body) {
-            t.ifError(err);
-            t.equal(res.statusCode, 200, 'a.txt should be found');
-            t.equal(res.headers['cache-control'], 'max-meh=2');
-            server.close(function() { t.end(); });
-          });
-        });
-
+      request.get('http://localhost:' + port + '/a.txt', function(err, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200, 'a.txt should be found');
+        t.equal(res.headers['cache-control'], 'max-meh=2');
+        server.close(function() { t.end(); });
       });
+
     });
   });
 });

--- a/test/cache.js
+++ b/test/cache.js
@@ -3,7 +3,7 @@ var test = require('tap').test,
     request = require('request'),
     ecstatic = require('../');
 
-test('custom cache-content number', function(t) {
+test('custom cache option number', function(t) {
   try {
     var server = http.createServer(ecstatic({
       root: __dirname + '/public/',
@@ -27,7 +27,7 @@ test('custom cache-content number', function(t) {
   });
 });
 
-test('custom cache-content string', function(t) {
+test('custom cache option string', function(t) {
   try {
     var server = http.createServer(ecstatic({
       root: __dirname + '/public/',
@@ -51,7 +51,7 @@ test('custom cache-content string', function(t) {
   });
 });
 
-test('custom cache-content function returning a number', function(t) {
+test('custom cache option function returning a number', function(t) {
   var i = 0
   try {
     var server = http.createServer(ecstatic({
@@ -86,7 +86,7 @@ test('custom cache-content function returning a number', function(t) {
   });
 });
 
-test('custom cache-content function returning a string', function(t) {
+test('custom cache option function returning a string', function(t) {
   var i = 0
   try {
     var server = http.createServer(ecstatic({

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,0 +1,132 @@
+var test = require('tap').test,
+    http = require('http'),
+    request = require('request'),
+    ecstatic = require('../');
+
+test('custom cache-content number', function(t) {
+  try {
+    var server = http.createServer(ecstatic({
+      root: __dirname + '/public/',
+      cache: 3600
+    }));
+  } catch (e) {
+    t.fail(e.message);
+    t.end();
+  }
+
+  t.plan(3);
+
+  server.listen(0, function() {
+    var port = server.address().port;
+    request.get('http://localhost:' + port + '/a.txt', function(err, res, body) {
+      t.ifError(err);
+      t.equal(res.statusCode, 200, 'a.txt should be found');
+      t.equal(res.headers['cache-control'], 'max-age=3600');
+      server.close(function() { t.end(); });
+    });
+  });
+});
+
+test('custom cache-content string', function(t) {
+  try {
+    var server = http.createServer(ecstatic({
+      root: __dirname + '/public/',
+      cache: 'max-whatever=3600'
+    }));
+  } catch (e) {
+    t.fail(e.message);
+    t.end();
+  }
+
+  t.plan(3);
+
+  server.listen(0, function() {
+    var port = server.address().port;
+    request.get('http://localhost:' + port + '/a.txt', function(err, res, body) {
+      t.ifError(err);
+      t.equal(res.statusCode, 200, 'a.txt should be found');
+      t.equal(res.headers['cache-control'], 'max-whatever=3600');
+      server.close(function() { t.end(); });
+    });
+  });
+});
+
+test('custom cache-content function returning a number', function(t) {
+  var i = 0
+  try {
+    var server = http.createServer(ecstatic({
+      root: __dirname + '/public/',
+      cache: function() {
+        i++
+        return i
+      }
+    }));
+  } catch (e) {
+    t.fail(e.message);
+    t.end();
+  }
+
+  t.plan(6);
+
+  server.listen(0, function() {
+    var port = server.address().port;
+    request.get('http://localhost:' + port + '/a.txt', function(err, res, body) {
+      t.ifError(err);
+      t.equal(res.statusCode, 200, 'a.txt should be found');
+      t.equal(res.headers['cache-control'], 'max-age=1');
+      server.close(function() {
+
+        server.listen(0, function() {
+          var port = server.address().port;
+          request.get('http://localhost:' + port + '/a.txt', function(err, res, body) {
+            t.ifError(err);
+            t.equal(res.statusCode, 200, 'a.txt should be found');
+            t.equal(res.headers['cache-control'], 'max-age=2');
+            server.close(function() { t.end(); });
+          });
+        });
+
+      });
+    });
+  });
+});
+
+test('custom cache-content function returning a string', function(t) {
+  var i = 0
+  try {
+    var server = http.createServer(ecstatic({
+      root: __dirname + '/public/',
+      cache: function() {
+        i++
+        return 'max-meh=' + i
+      }
+    }));
+  } catch (e) {
+    t.fail(e.message);
+    t.end();
+  }
+
+  t.plan(6);
+
+  server.listen(0, function() {
+    var port = server.address().port;
+    request.get('http://localhost:' + port + '/a.txt', function(err, res, body) {
+      t.ifError(err);
+      t.equal(res.statusCode, 200, 'a.txt should be found');
+      t.equal(res.headers['cache-control'], 'max-meh=1');
+      server.close(function() {
+
+        server.listen(0, function() {
+          var port = server.address().port;
+          request.get('http://localhost:' + port + '/a.txt', function(err, res, body) {
+            t.ifError(err);
+            t.equal(res.statusCode, 200, 'a.txt should be found');
+            t.equal(res.headers['cache-control'], 'max-meh=2');
+            server.close(function() { t.end(); });
+          });
+        });
+
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes #94

I didn't see any tests involving cache-control or I would have added to them.