### PR TITLE
Add opts.showDotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ If it is a function, it will be executed on every request, and passed the pathna
 
 Turn **off** directory listings with `opts.showDir === false`. Defaults to **true**.
 
+### `opts.showDotfiles`
+
+Exclude dotfiles from directory listings with `opts.showDotfiles === false`. Defaults to **true**.
+
 ### `opts.humanReadable`
 
 If showDir is enabled, add human-readable file sizes. Defaults to **true**.

--- a/lib/ecstatic/aliases.json
+++ b/lib/ecstatic/aliases.json
@@ -1,6 +1,7 @@
 {
   "autoIndex": [ "autoIndex", "autoindex" ],
   "showDir": [ "showDir", "showdir" ],
+  "showDotfiles": ["showDotfiles", "showdotfiles"],
   "humanReadable": [ "humanReadable", "humanreadable", "human-readable" ],
   "si": [ "si", "index" ],
   "handleError": [ "handleError", "handleerror" ],

--- a/lib/ecstatic/defaults.json
+++ b/lib/ecstatic/defaults.json
@@ -1,6 +1,7 @@
 {
   "autoIndex": true,
   "showDir": true,
+  "showDotfiles": true,
   "humanReadable": true,
   "si": false,
   "cache": "max-age=3600",

--- a/lib/ecstatic/opts.js
+++ b/lib/ecstatic/opts.js
@@ -6,6 +6,7 @@ var aliases = require('./aliases.json')
 module.exports = function (opts) {
   var autoIndex = defaults.autoIndex,
       showDir = defaults.showDir,
+      showDotfiles = defaults.showDotfiles,
       humanReadable = defaults.humanReadable,
       si = defaults.si,
       cache = defaults.cache,
@@ -35,6 +36,13 @@ module.exports = function (opts) {
     aliases.showDir.some(function (k) {
       if (isDeclared(k)) {
         showDir = opts[k];
+        return true;
+      }
+    });
+
+    aliases.showDotfiles.some(function (k) {
+      if (isDeclared(k)) {
+        showDotfiles = opts[k];
         return true;
       }
     });
@@ -154,6 +162,7 @@ module.exports = function (opts) {
     cache: cache,
     autoIndex: autoIndex,
     showDir: showDir,
+    showDotfiles: showDotfiles,
     humanReadable: humanReadable,
     si: si,
     defaultExt: defaultExt,

--- a/lib/ecstatic/showdir.js
+++ b/lib/ecstatic/showdir.js
@@ -13,6 +13,7 @@ module.exports = function (opts, stat) {
       baseDir = opts.baseDir,
       humanReadable = opts.humanReadable,
       handleError = opts.handleError,
+      showDotfiles = opts.showDotfiles,
       si = opts.si,
       weakEtags = opts.weakEtags;
 
@@ -40,6 +41,14 @@ module.exports = function (opts, stat) {
         if (err) {
           return handleError ? status[500](res, next, { error: err }) : next();
         }
+
+        // Optionally exclude dotfiles from directory listing.
+        if (!showDotfiles) {
+          files = files.filter(function(filename){
+            return filename.slice(0,1) !== '.';
+          });
+        }
+
         res.setHeader('content-type', 'text/html');
         res.setHeader('etag', etag(stat, weakEtags));
         res.setHeader('last-modified', (new Date(stat.mtime)).toUTCString());


### PR DESCRIPTION
Thought it'd be useful to be able to exclude dotfiles from directory listings. This came up when I wanted to use ecstatic to create a quick local server to share a directory of files with a non-technical coworker. It doesn't affect `../`links.