### PR TITLE
Add showDotfiles to main opts example in README.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -52,3 +52,4 @@ Listed in no particular order:
 * Zach Bruggerman @remixz <mail@bruggie.com>
 * Mathias Bynens @mathiasbynens
 * Chris Lee @clee <clee@mg8.org>
+* Cam Wiegert @camwiegert <cam@camwiegert.com>

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ var opts = {
              baseDir            : '/',
              cache              : 3600,
              showDir            : true,
+             showDotfiles       : true,
              autoIndex          : false,
              humanReadable      : true,
              headers            : {},


### PR DESCRIPTION
Adds showDotfiles to main opts example in README. Also took the opportunity to update the CONTRIBUTORS.

```js
var opts = {
             root               : __dirname + '/public',
             baseDir            : '/',
             cache              : 3600,
             showDir            : true,
             showDotfiles       : true,
             autoIndex          : false,
             humanReadable      : true,
             headers            : {},
             si                 : false,
             defaultExt         : 'html',
             gzip               : false,
             serverHeader       : true,
             contentType        : 'application/octet-stream',
             mimeTypes          : undefined,
             handleOptionsMethod: false
           }
```