### PR TITLE
Allow setting mimeTypes via cli

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -36,6 +36,9 @@ var ecstatic = module.exports = function (dir, options) {
 
   // Support hashes and .types files in mimeTypes @since 0.8
   if (opts.mimeTypes) {
+    try {
+      opts.mimeTypes = JSON.parse(opts.mimeTypes);
+    } catch (e) {}
     if (typeof opts.mimeTypes === 'string') {
       mime.load(opts.mimeTypes);
     }

--- a/test/custom-content-type-json-string.js
+++ b/test/custom-content-type-json-string.js
@@ -1,0 +1,30 @@
+var test = require('tap').test,
+    http = require('http'),
+    request = require('request'),
+    ecstatic = require('../');
+
+test('custom contentType as stringified JSON. Ref: #169', function(t) {
+  try {
+    var server = http.createServer(ecstatic({
+      root: __dirname + '/public/',
+      mimetype: JSON.stringify({
+        'application/jon': ['opml']
+      })
+    }));
+  } catch (e) {
+    t.fail(e.message);
+    t.end();
+  }
+
+  t.plan(3);
+
+  server.listen(0, function() {
+    var port = server.address().port;
+    request.get('http://localhost:' + port + '/custom_mime_type.opml', function(err, res, body) {
+      t.ifError(err);
+      t.equal(res.statusCode, 200, 'custom_mime_type.opml should be found');
+      t.equal(res.headers['content-type'], 'application/jon; charset=utf-8');
+      server.close(function() { t.end(); });
+    });
+  });
+});


### PR DESCRIPTION
This patch enables the following, for cases where maintaining a .types file is overkill:

`ecstatic ./data --port 1337 --mimeTypes '{ "application/x-my-type": ["x-mt"] }'`