### PR TITLE
[test][fix] Set "Connection: close" header on malformed test request.

### DIFF
--- a/test/malformed.js
+++ b/test/malformed.js
@@ -14,6 +14,7 @@ test('malformed uri', function (t) {
     var r = http.get({
       host: 'localhost',
       port: server.address().port,
+      headers: { Connection: 'close' },
       path: '/%'
     });
     r.on('response', function (res) {


### PR DESCRIPTION
Fixes #170, a test timeout due to dangling listeners.