### PR TITLE
fix wrong localhost on Windows - now passing

### DIFF
--- a/test/process-env-port.js
+++ b/test/process-env-port.js
@@ -6,16 +6,16 @@ var test = require('tap').test,
     insanePorts = [1023, 65537, Infinity, 'wow'];
 
 test('sane port', function (t) {
-  startServer('http://0.0.0.0:' + sanePort, sanePort, t);
+  startServer('http://127.0.0.1:' + sanePort, sanePort, t);
 });
 
 test('floating point port', function (t) {
-  startServer('http://0.0.0.0:9090', floatingPointPort, t);
+  startServer('http://127.0.0.1:9090', floatingPointPort, t);
 });
 
 insanePorts.forEach(function (port) {
   test('insane port: ' + port, function (t) {
-    startServer('http://0.0.0.0:8000', port, t);
+    startServer('http://127.0.0.1:8000', port, t);
   })
 });
 


### PR DESCRIPTION
Unless you want ecstatic to listen to no particular address, then 0.0.0.0 is wrong.
http://www.howtogeek.com/225487/what-is-the-difference-between-127.0.0.1-and-0.0.0.0/

*Fix failing test on Windows*