### PR TITLE
Illegal access crash from if-modified-since header

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -276,8 +276,14 @@ var ecstatic = module.exports = function (dir, options) {
         return false;
       }
 
+      // Catch "illegal access" dates that will crash v8
+      try {
+        var modifiedDate = new Date(Date.parse(modifiedSince));
+      }
+      catch (err) { return false }
+
       // If any of the headers provided don't match, then don't return 304
-      if (modifiedSince && (new Date(Date.parse(modifiedSince))) < stat.mtime) {
+      if (modifiedSince && modifiedDate < stat.mtime) {
         return false;
       }
 

--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -277,14 +277,19 @@ var ecstatic = module.exports = function (dir, options) {
       }
 
       // Catch "illegal access" dates that will crash v8
-      try {
-        var modifiedDate = new Date(Date.parse(modifiedSince));
-      }
-      catch (err) { return false }
+      if (modifiedSince) {
+        try {
+          var modifiedDate = new Date(Date.parse(modifiedSince));
+        }
+        catch (err) { return false }
 
-      // If any of the headers provided don't match, then don't return 304
-      if (modifiedSince && modifiedDate < stat.mtime) {
-        return false;
+        if (modifiedDate.toString() === 'Invalid Date') {
+          return false;
+        }
+        // If any of the headers provided don't match, then don't return 304
+        if (modifiedDate < stat.mtime) {
+          return false;
+        }
       }
 
       if (clientEtag) {

--- a/test/illegal-access-date.js
+++ b/test/illegal-access-date.js
@@ -1,0 +1,24 @@
+var test = require('tap').test,
+    ecstatic = require('../lib/ecstatic'),
+    http = require('http'),
+    path = require('path'),
+    request = require('request');
+
+test('if-modified-since illegal access date', function (t) {
+  var dir = path.join(__dirname, 'public');
+  var server = http.createServer(ecstatic(dir))
+  
+  t.plan(2);
+  
+  server.listen(0, function () {
+    var opts = {
+      url: 'http://localhost:' + server.address().port + '/a.txt',
+      headers: { 'if-modified-since': '275760-09-24' }
+    };
+    request.get(opts, function (err, res, body) {
+      t.ifError(err);
+      t.equal(res.statusCode, 200);
+      server.close(function() { t.end(); });
+    });
+  });
+});


### PR DESCRIPTION
node inherits a bug from v8 where some dates raise exceptions instead of returning an `Invalid Date` object:

```
$ node
> new Date('275760-09-12')
Fri Sep 12 275760 00:00:00 GMT-0400 (EDT)
> new Date('275760-09-13')
Invalid Date
> new Date('275760-09-23')
Invalid Date
> new Date('275760-09-24')
illegal access
> new Date('275760-10-13')
illegal access
> new Date('275760-10-14')
Invalid Date
> ^D
$ node -v
v4.2.1
```

Knowing this, it's possible to crash ecstatic by sending a malicious `If-Modified-Since` header:

```
$ mkdir /tmp/xyz
$ echo '<h1>doot doot</h1>' > /tmp/xyz/index.html
$ ecstatic -p 5000 /tmp/xyz &
[1] 11994
$ curl -H if-modified-since:275760-09-24 http://localhost:5000/index.html

/home/substack/projects/node-ecstatic/lib/ecstatic.js:280
      if (modifiedSince && (new Date(Date.parse(modifiedSince))) < stat.mtime) {
                                          ^
illegal access
curl: (52) Empty reply from server
[1]+  Exit 1                  ecstatic -p 5000 /tmp/xyz
```

This patch guards the `Date` instance with a try/catch to prevent these v8 bugs from bringing down ecstatic.