### PR TITLE
Do not redirect / add trailing slash when showDir and autoIndex are off.

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -124,6 +124,11 @@ var ecstatic = module.exports = function (dir, options) {
           status[500](res, next, { error: err });
         }
         else if (stat.isDirectory()) {
+          if (!autoIndex && !opts.showDir) {
+            status[404](res, next);
+            return;
+          }
+
           // 302 to / if necessary
           if (!parsed.pathname.match(/\/$/)) {
             res.statusCode = 302;
@@ -151,8 +156,6 @@ var ecstatic = module.exports = function (dir, options) {
           if (opts.showDir) {
             return showDir(opts, stat)(req, res);
           }
-
-          status[404](res, next);
 
         }
         else {

--- a/test/trailing-slash.js
+++ b/test/trailing-slash.js
@@ -1,0 +1,24 @@
+var test = require('tap').test,
+    ecstatic = require('../'),
+    http = require('http'),
+    request = require('request');
+
+test('should not add trailing slash when showDir and autoIndex are off', function (t) {
+  t.plan(3);
+  var server = http.createServer(
+    ecstatic({
+      root: __dirname + '/public',
+      autoIndex: false,
+      showDir: false
+    })
+  );
+  t.on('end', function () { server.close() })
+  server.listen(0, function () {
+    var port = server.address().port;
+    request.get('http://localhost:' + port + '/subdir', function (err, res, body) {
+      t.ifError(err);
+      t.equal(res.statusCode, 404);
+      t.equal(res.body, 'File not found. :(');
+    });
+  });
+});


### PR DESCRIPTION
When both `showDir` and `autoIndex` options are OFF we do not serve directories in any form. So if the client requests `/foo` and `foo` is a directory, we should NOT handle the request at all. It doesn't make sense to redirect them to `/foo/` because we won't be able handle that path either. This creates an un-necessary round-trip and perhaps more importantly it exposes details about our filesystem structure.