### PR TITLE
utf8 forbidden in headers since nodejs 4.3.0

### DIFF
--- a/lib/ecstatic/etag.js
+++ b/lib/ecstatic/etag.js
@@ -1,5 +1,5 @@
 module.exports = function (stat, weakEtag) {
-  var etag = '"' + [stat.ino, stat.size, JSON.stringify(stat.mtime)].join('-') + '"';
+  var etag = '"' + [stat.ino, stat.size, JSON.stringify(stat.mtime.getTime())].join('-') + '"';
   if (weakEtag) {
     etag = 'W/' + etag;
   }


### PR DESCRIPTION
national characters are used in date if non-US locale
https://github.com/nodejs/node/blob/v4.3.0/lib/_http_common.js#L219