### PR TITLE
Improve correctness and efficiency of cache validation code

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -227,7 +227,8 @@ var ecstatic = module.exports = function (dir, options) {
 
       // TODO: Helper for this, with default headers.
       res.setHeader('etag', etag(stat, weakEtags));
-      res.setHeader('last-modified', (new Date(stat.mtime)).toUTCString());
+      var lastModified = (new Date(stat.mtime)).toUTCString();
+      res.setHeader('last-modified', lastModified);
 
       if (typeof cache === 'function') {
         var requestSpecificCache = cache(pathname);
@@ -240,7 +241,7 @@ var ecstatic = module.exports = function (dir, options) {
       }
 
       // Return a 304 if necessary
-      if (shouldReturn304(req, stat)) {
+      if (shouldReturn304(req, stat, lastModified)) {
         return status[304](res, next);
       }
 
@@ -266,7 +267,7 @@ var ecstatic = module.exports = function (dir, options) {
 
     // Do a strong or weak etag comparison based on setting
     // https://www.ietf.org/rfc/rfc2616.txt Section 13.3.3
-    function shouldReturn304(req, stat) {
+    function shouldReturn304(req, stat, serverLastModified) {
       if (!req || !req.headers) {
         return false;
       }
@@ -292,7 +293,7 @@ var ecstatic = module.exports = function (dir, options) {
           return false;
         }
         // If any of the headers provided don't match, then don't return 304
-        if (modifiedDate < stat.mtime) {
+        if (modifiedDate < new Date(serverLastModified)) {
           return false;
         }
       }

--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -266,8 +266,6 @@ var ecstatic = module.exports = function (dir, options) {
       });
     }
 
-    // Do a strong or weak etag comparison based on setting
-    // https://www.ietf.org/rfc/rfc2616.txt Section 13.3.3
     function shouldReturn304(req, serverLastModified, serverEtag) {
       if (!req || !req.headers) {
         return false;
@@ -281,9 +279,9 @@ var ecstatic = module.exports = function (dir, options) {
         return false;
       }
 
-      // Catch "illegal access" dates that will crash v8
-      // https://github.com/jfhbrook/node-ecstatic/pull/179
       if (clientModifiedSince) {
+        // Catch "illegal access" dates that will crash v8
+        // https://github.com/jfhbrook/node-ecstatic/pull/179
         try {
           var clientModifiedDate = new Date(Date.parse(clientModifiedSince));
         }
@@ -292,13 +290,15 @@ var ecstatic = module.exports = function (dir, options) {
         if (clientModifiedDate.toString() === 'Invalid Date') {
           return false;
         }
-        // If any of the headers provided don't match, then don't return 304
+        // If the client's copy is older than the server's, don't return 304
         if (clientModifiedDate < new Date(serverLastModified)) {
           return false;
         }
       }
 
       if (clientEtag) {
+        // Do a strong or weak etag comparison based on setting
+        // https://www.ietf.org/rfc/rfc2616.txt Section 13.3.3
         if (opts.weakCompare && clientEtag !== serverEtag
           && clientEtag !== ('W/' + serverEtag) && ('W/' + clientEtag) !== serverEtag) {
           return false;

--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -10,7 +10,7 @@ var path = require('path'),
       fs.readFileSync(__dirname + '/../package.json').toString()
     ).version,
     status = require('./ecstatic/status-handlers'),
-    etag = require('./ecstatic/etag'),
+    generateEtag = require('./ecstatic/etag'),
     optsParser = require('./ecstatic/opts');
 
 var ecstatic = module.exports = function (dir, options) {
@@ -226,9 +226,10 @@ var ecstatic = module.exports = function (dir, options) {
       }
 
       // TODO: Helper for this, with default headers.
-      res.setHeader('etag', etag(stat, weakEtags));
-      var lastModified = (new Date(stat.mtime)).toUTCString();
+      var lastModified = (new Date(stat.mtime)).toUTCString(),
+          etag = generateEtag(stat, weakEtags);
       res.setHeader('last-modified', lastModified);
+      res.setHeader('etag', etag);
 
       if (typeof cache === 'function') {
         var requestSpecificCache = cache(pathname);
@@ -241,7 +242,7 @@ var ecstatic = module.exports = function (dir, options) {
       }
 
       // Return a 304 if necessary
-      if (shouldReturn304(req, stat, lastModified)) {
+      if (shouldReturn304(req, lastModified, etag)) {
         return status[304](res, next);
       }
 
@@ -267,14 +268,13 @@ var ecstatic = module.exports = function (dir, options) {
 
     // Do a strong or weak etag comparison based on setting
     // https://www.ietf.org/rfc/rfc2616.txt Section 13.3.3
-    function shouldReturn304(req, stat, serverLastModified) {
+    function shouldReturn304(req, serverLastModified, serverEtag) {
       if (!req || !req.headers) {
         return false;
       }
 
       var modifiedSince = req.headers['if-modified-since'],
-        clientEtag = req.headers['if-none-match'],
-        serverEtag = etag(stat, opts.weakEtags);
+        clientEtag = req.headers['if-none-match'];
 
       if (!modifiedSince && !clientEtag) {
         // Client did not provide any conditional caching headers

--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -273,27 +273,27 @@ var ecstatic = module.exports = function (dir, options) {
         return false;
       }
 
-      var modifiedSince = req.headers['if-modified-since'],
-        clientEtag = req.headers['if-none-match'];
+      var clientModifiedSince = req.headers['if-modified-since'],
+          clientEtag = req.headers['if-none-match'];
 
-      if (!modifiedSince && !clientEtag) {
+      if (!clientModifiedSince && !clientEtag) {
         // Client did not provide any conditional caching headers
         return false;
       }
 
       // Catch "illegal access" dates that will crash v8
       // https://github.com/jfhbrook/node-ecstatic/pull/179
-      if (modifiedSince) {
+      if (clientModifiedSince) {
         try {
-          var modifiedDate = new Date(Date.parse(modifiedSince));
+          var clientModifiedDate = new Date(Date.parse(clientModifiedSince));
         }
         catch (err) { return false }
 
-        if (modifiedDate.toString() === 'Invalid Date') {
+        if (clientModifiedDate.toString() === 'Invalid Date') {
           return false;
         }
         // If any of the headers provided don't match, then don't return 304
-        if (modifiedDate < new Date(serverLastModified)) {
+        if (clientModifiedDate < new Date(serverLastModified)) {
           return false;
         }
       }

--- a/test/304.js
+++ b/test/304.js
@@ -24,8 +24,7 @@ test('304_not_modified', function (t) {
   );
 
   server.listen(port, function () {
-    var uri = 'http://localhost:' + port + path.join('/', baseDir, file),
-        now = (new Date()).toString();
+    var uri = 'http://localhost:' + port + path.join('/', baseDir, file);
 
     request.get({
       uri: uri,
@@ -38,7 +37,7 @@ test('304_not_modified', function (t) {
       request.get({
         uri: uri,
         followRedirect: false,
-        headers: { 'if-modified-since': now }
+        headers: { 'if-modified-since': res.headers['last-modified'] }
       }, function (err, res, body) {
         if (err) t.fail(err);
 


### PR DESCRIPTION
I recently noticed that I was only ever getting 200's from ecstatic and tracked the issue down to `stat.mtime` having millisecond resolution on my system, which is more than what's included in the date string sent in the last-modified header.

The test doesn't fail because it's not doing what I think browsers do and what the spec seems to be recommending:
> To get best results when sending an If-Modified-Since header field for cache validation, clients are advised to use the exact date string received in a previous Last-Modified header field whenever possible.

I updated the test accordingly and discovered it still didn't fail on my laptop, where mtimes seem to be lower resolution, but maybe it will fail at travis?