### PR TITLE
Fix icon styles in showdir when text is wrapping in multiple lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Remove support for 0.12.0
 - Remove union examples and test harnesses (support should have been removed
   long ago)
+- Fix icon styles in directory listing for small screens
 
 2017/06/06 Version 2.2.1
 - Fix version number in CHANGELOG.md

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -60,3 +60,4 @@ Listed in no particular order:
 * Drew Harwell @fenwick67
 * Vamsi Krishna Avula @avamsi
 * @wood1986
+* Mahdi Hasheminejad @mahdi-ninja

--- a/lib/ecstatic/show-dir/index.js
+++ b/lib/ecstatic/show-dir/index.js
@@ -108,7 +108,7 @@ module.exports = (opts) => {
 
             // TODO: use stylessheets?
             html += `${'<tr>' +
-              '<td class="icon-parent"><i class="'}${iconClass}"></i></td>` +
+              '<td><i class="icon '}${iconClass}"></i></td>` +
               `<td class="perms"><code>(${permsToString(file[1])})</code></td>` +
               `<td class="file-size"><code>${sizeToString(file[1], humanReadable, si)}</code></td>` +
               `<td class="display-name"><a href="${href}">${displayName}</a></td>` +

--- a/lib/ecstatic/show-dir/styles.js
+++ b/lib/ecstatic/show-dir/styles.js
@@ -4,14 +4,13 @@ const icons = require('./icons.json');
 
 const IMG_SIZE = 16;
 
-let css = `td.icon-parent { height: ${IMG_SIZE}px; width: ${IMG_SIZE}px; }\n`;
+let css = `i.icon { display: block; height: ${IMG_SIZE}px; width: ${IMG_SIZE}px; }\n`;
 css += 'td.perms {}\n';
 css += 'td.file-size { text-align: right; padding-left: 1em; }\n';
 css += 'td.display-name { padding-left: 1em; }\n';
 
 Object.keys(icons).forEach((key) => {
   css += `i.icon-${key} {\n`;
-  css += '  display: block; width: 100%; height: 100%; background-repeat: no-repeat;\n';
   css += `  background: url("data:image/png;base64,${icons[key]}");\n`;
   css += '}\n\n';
 });


### PR DESCRIPTION
Before fix:
![Before fix](https://user-images.githubusercontent.com/9942431/29494428-9466790c-85ed-11e7-8916-b100c7e7978d.png)

After fix:
![After fix](https://user-images.githubusercontent.com/9942431/29494427-9450bf90-85ed-11e7-99bc-4535d3876c56.png)
