### PR TITLE
fixed CSS and layout

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -62,3 +62,4 @@ Listed in no particular order:
 * @wood1986
 * Mahdi Hasheminejad @mahdi-ninja
 * Bradley Farias @bmeck <bradley.meck@gmail.com>
+* David Refoua @DRSDavidSoft <david@refoua.me>

--- a/lib/ecstatic/show-dir/styles.js
+++ b/lib/ecstatic/show-dir/styles.js
@@ -11,7 +11,7 @@ css += 'td.display-name { padding-left: 1em; }\n';
 
 Object.keys(icons).forEach((key) => {
   css += `i.icon-${key} {\n`;
-  css += `  background: url("data:image/png;base64,${icons[key]}");\n`;
+  css += `  background-image: url("data:image/png;base64,${icons[key]}");\n`;
   css += '}\n\n';
 });
 

--- a/lib/ecstatic/show-dir/styles.js
+++ b/lib/ecstatic/show-dir/styles.js
@@ -5,6 +5,7 @@ const icons = require('./icons.json');
 const IMG_SIZE = 16;
 
 let css = `i.icon { display: block; height: ${IMG_SIZE}px; width: ${IMG_SIZE}px; }\n`;
+css += 'table tr { white-space: nowrap; }\n';
 css += 'td.perms {}\n';
 css += 'td.file-size { text-align: right; padding-left: 1em; }\n';
 css += 'td.display-name { padding-left: 1em; }\n';


### PR DESCRIPTION
1. Using `background` instead of `background-image` will override previously set attributes such as `background-repeat: no-repeat` which is undesirable

2. Since the table is not automatically width-fixed, we have to disable line breaking in order to show the entire path (and permissions) in one line

## Preview
<img width="625" alt="fix-1" src="https://user-images.githubusercontent.com/4673812/33793652-7c0c1562-dcd0-11e7-8f06-2702402fb03e.png">
