### PR TITLE
Fix codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,7 @@ node_js:
 install:
   - npm install
   - npm update
+script:
+  - npm test
+after_success:
+    - bash <(curl -s https://codecov.io/bash)

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,12 +80,6 @@
         "sprintf-js": "1.0.3"
       }
     },
-    "argv": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
-      "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
-      "dev": true
-    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -287,77 +281,6 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
-    },
-    "codecov": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-2.2.0.tgz",
-      "integrity": "sha1-LQaBfOuIkeymNog21Ptr9swE/9E=",
-      "dev": true,
-      "requires": {
-        "argv": "0.0.2",
-        "request": "2.79.0",
-        "urlgrey": "0.4.4"
-      },
-      "dependencies": {
-        "caseless": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-          "dev": true
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.9.0",
-            "is-my-json-valid": "2.16.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "qs": {
-          "version": "6.3.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.79.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "qs": "6.3.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.4.3",
-            "uuid": "3.0.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "dev": true
-        }
-      }
     },
     "color-support": {
       "version": "1.1.3",
@@ -4365,12 +4288,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.2.tgz",
       "integrity": "sha1-wHJ1aWetJLi1nldBVRyqx49QuLc="
-    },
-    "urlgrey": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
-      "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
-      "dev": true
     },
     "user-home": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "fix": "eslint --fix ./lib/ ./example/ ./test",
     "pretest": "eslint ./lib/ ./example/ ./test",
-    "test": "tap --coverage test/*.js",
-    "posttest": "tap --coverage-report=text-lcov | codecov"
+    "test": "tap --jobs-auto --coverage test/*.js",
+    "posttest": "tap --coverage-report=clover"
   },
   "bin": "./lib/ecstatic.js",
   "keywords": [
@@ -31,8 +31,7 @@
     "url-join": "^2.0.2"
   },
   "devDependencies": {
-    "codecov": "^2.2.0",
-    "eol": "^0.9.0",
+    "eol": "^0.9.1",
     "eslint": "^3.19.0",
     "eslint-config-airbnb-base": "^11.2.0",
     "eslint-plugin-import": "^2.3.0",


### PR DESCRIPTION
This remove the node version of codecov and uses the bash version instead.

So the longer any nonsense codecov when doing local `npm test` also I put in an auto job flag for `tap`, so if you got multiple processors, it should speed up tests.

Hurry up and merge this in :) Then I can rebase #209 to master and we see if PR's adds or lower the coverage. But we need at least one coverage report in master before it works.

oh, and I also changed from lcov to clover reports - not sure what the difference is but I found an example with clover and codecov...