### PR TITLE
Fix 416 if there are spaces in range header

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -262,7 +262,7 @@ module.exports = function createMiddleware(_dir, _options) {
 
       if (range) {
         const total = stat.size;
-        const parts = range.replace(/bytes=/, '').split('-');
+        const parts = range.trim().replace(/bytes=/, '').split('-');
         const partialstart = parts[0];
         const partialend = parts[1];
         const start = parseInt(partialstart, 10);


### PR DESCRIPTION
According to [RFC 2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html):

> 4.2 Message Headers
> ...
> The field-content does not include any leading or trailing LWS: linear white space occurring before the first non-whitespace character of the field-value or after the last non-whitespace character of the field-value. Such leading or trailing LWS MAY be removed without changing the semantics of the field value.

But if header `Range` doesn't contain \<range-end\>, but contains space after `-` → then `parseInt(' ', 10)` returns NaN and ecstatic responses with 416 Range Not Satisfiable.

Real client request and response example:
<img width="261" alt="screen shot 2018-04-27 at 22 05 54" src="https://user-images.githubusercontent.com/15016227/39380470-55f19bfe-4a67-11e8-8f96-9b65e2526ac8.png">
<img width="356" alt="screen shot 2018-04-27 at 22 06 20" src="https://user-images.githubusercontent.com/15016227/39380487-695f2b48-4a67-11e8-9274-b9d930c12019.png">
