### PR TITLE
Remove extra double quotes in ETAG inserted by JSON.stringify

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -65,3 +65,4 @@ Listed in no particular order:
 * David Refoua @DRSDavidSoft <david@refoua.me>
 * @mmmm1998 <warquark@gmail.com>
 * Victor Didenko @victordidenko
+* Zong Jhe Wu @s25g5d4

--- a/lib/ecstatic/etag.js
+++ b/lib/ecstatic/etag.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = (stat, weakEtag) => {
-  let etag = `"${[stat.ino, stat.size, JSON.stringify(stat.mtime)].join('-')}"`;
+  let etag = `"${[stat.ino, stat.size, stat.mtime.toISOString()].join('-')}"`;
   if (weakEtag) {
     etag = `W/${etag}`;
   }


### PR DESCRIPTION
Hi there. According to [RFC7232 section 2.3.](https://tools.ietf.org/html/rfc7232#section-2.3), a valid etag value should be double-qouted and string between should contains no double quote character itself. While it doesn't seem to break any browser, it is kind of feeling weird each time I inspect the headers when I'm debuging some other things.

There're not much difference after this PR applied. the string is almost the same, only with the double qoutes being removed when converting Date object to plain string. Internally `JSON.stringify()` calls `Date.prototype.toJSON()` on Date objects to get a valid JSON representation of its value, and `toJSON()` is implemented to return the returned value of `Date.prototype.toISOString()`. So here I removed `JSON.stringify()` and made a direct call to `toISOString()`.

Headers **before** patch applied:

```
$ curl -so /dev/null -D - http://127.0.0.1:8080
HTTP/1.1 200 OK
server: ecstatic-3.2.0
Access-Control-Allow-Origin: *
Access-Control-Allow-Headers: Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since
cache-control: max-age=3600
last-modified: Fri, 06 Jul 2018 04:41:35 GMT
etag: W/"2266206-15946-"2018-07-06T04:41:35.507Z""
content-length: 15946
content-type: text/html; charset=UTF-8
Date: Fri, 06 Jul 2018 07:48:18 GMT
Connection: keep-alive
```

Headers **after** patch applied:

```
$ curl -so /dev/null -D - http://127.0.0.1:8080
HTTP/1.1 200 OK
server: ecstatic-3.2.0
Access-Control-Allow-Origin: *
Access-Control-Allow-Headers: Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since
cache-control: max-age=3600
last-modified: Fri, 06 Jul 2018 04:41:35 GMT
etag: W/"2266206-15946-2018-07-06T04:41:35.507Z"
content-length: 15946
content-type: text/html; charset=UTF-8
Date: Fri, 06 Jul 2018 07:46:44 GMT
Connection: keep-alive
```

It would be appreciated if you could take a look. Thanks.