### PR TITLE
Fix bad parsing on CORS option

### DIFF
--- a/lib/ecstatic/opts.js
+++ b/lib/ecstatic/opts.js
@@ -114,7 +114,7 @@ module.exports = (opts) => {
     });
 
     aliases.cors.forEach((k) => {
-      if (isDeclared(k) && k) {
+      if (isDeclared(k) && opts[k]) {
         handleOptionsMethod = true;
         headers['Access-Control-Allow-Origin'] = '*';
         headers['Access-Control-Allow-Headers'] = 'Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since';

--- a/test/cors.js
+++ b/test/cors.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const test = require('tap').test;
+const ecstatic = require('../lib/ecstatic');
+const http = require('http');
+const request = require('request');
+
+const root = `${__dirname}/public`;
+
+test('cors defaults to false', (t) => {
+  t.plan(4);
+
+  const server = http.createServer(
+    ecstatic({
+      root,
+      autoIndex: true,
+      defaultExt: 'html',
+    })
+  );
+
+  server.listen(() => {
+    const port = server.address().port;
+    const uri = `http://localhost:${port}/subdir/index.html`;
+
+    request.get({ uri }, (err, res) => {
+      t.ifError(err);
+      t.equal(res.statusCode, 200);
+      t.type(res.headers['access-control-allow-origin'], 'undefined');
+      t.type(res.headers['access-control-allow-headers'], 'undefined');
+    });
+  });
+  t.once('end', () => {
+    server.close();
+  });
+});
+
+test('cors set to false', (t) => {
+  t.plan(4);
+
+  const server = http.createServer(
+    ecstatic({
+      root,
+      cors: false,
+      autoIndex: true,
+      defaultExt: 'html',
+    })
+  );
+
+  server.listen(() => {
+    const port = server.address().port;
+    const uri = `http://localhost:${port}/subdir/index.html`;
+
+    request.get({ uri }, (err, res) => {
+      t.ifError(err);
+      t.equal(res.statusCode, 200);
+      t.type(res.headers['access-control-allow-origin'], 'undefined');
+      t.type(res.headers['access-control-allow-headers'], 'undefined');
+    });
+  });
+  t.once('end', () => {
+    server.close();
+  });
+});
+
+test('cors set to true', (t) => {
+  t.plan(4);
+
+  const server = http.createServer(
+    ecstatic({
+      root,
+      cors: true,
+      autoIndex: true,
+      defaultExt: 'html',
+    })
+  );
+
+  server.listen(() => {
+    const port = server.address().port;
+    const uri = `http://localhost:${port}/subdir/index.html`;
+    request.get({ uri }, (err, res) => {
+      t.ifError(err);
+      t.equal(res.statusCode, 200);
+      t.equal(res.headers['access-control-allow-origin'], '*');
+      t.equal(res.headers['access-control-allow-headers'], 'Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since');
+    });
+  });
+  t.once('end', () => {
+    server.close();
+  });
+});
+
+test('CORS set to true', (t) => {
+  t.plan(4);
+
+  const server = http.createServer(
+    ecstatic({
+      root,
+      CORS: true,
+      autoIndex: true,
+      defaultExt: 'html',
+    })
+  );
+
+  server.listen(() => {
+    const port = server.address().port;
+    const uri = `http://localhost:${port}/subdir/index.html`;
+    request.get({ uri }, (err, res) => {
+      t.ifError(err);
+      t.equal(res.statusCode, 200);
+      t.equal(res.headers['access-control-allow-origin'], '*');
+      t.equal(res.headers['access-control-allow-headers'], 'Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since');
+    });
+  });
+  t.once('end', () => {
+    server.close();
+  });
+});


### PR DESCRIPTION
Hi there, it's me again. As I metioned last time I was poking around the headers returned by node-ecstatic, I noticed that the CORS-related headers were set without any option provided by me. And even if I turn the option off explicitly, they still exist. It is not hard to find the problem, but I'm suprised that the problem exists for such a long time.

I also add a test, and hopefully that helps. I don't have much experience on writing tests.

Thanks for reviewing.