### PR TITLE
Trim whitespace from request encoding headers

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -38,7 +38,7 @@ function shouldCompress(req) {
   return headers && headers['accept-encoding'] &&
     headers['accept-encoding']
       .split(',')
-      .some(el => ['*', 'compress', 'gzip', 'deflate'].indexOf(el) !== -1)
+      .some(el => ['*', 'compress', 'gzip', 'deflate'].indexOf(el.trim()) !== -1)
     ;
 }
 

--- a/test/accept-encoding.js
+++ b/test/accept-encoding.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const test = require('tap').test;
+const ecstatic = require('../lib/ecstatic');
+const http = require('http');
+const request = require('request');
+
+const root = `${__dirname}/public`;
+
+test('properly handles whitespace in accept-encoding', (t) => {
+  t.plan(3);
+
+  const server = http.createServer(ecstatic({
+    root,
+    autoIndex: true,
+    gzip: true
+  }));
+
+  server.listen(() => {
+    const port = server.address().port;
+    const options = {
+      uri: `http://localhost:${port}/gzip`,
+      headers: {
+        'accept-encoding': ' gzip, deflate'
+      }
+    };
+
+    request.get(options, (err, res) => {
+      t.ifError(err);
+      t.equal(res.statusCode, 200);
+      t.equal(res.headers['content-encoding'], 'gzip');
+    });
+  });
+  t.once('end', () => {
+    server.close();
+  });
+});
+
+test('properly handles single accept-encoding entry', (t) => {
+  t.plan(3);
+
+  const server = http.createServer(ecstatic({
+    root,
+    autoIndex: true,
+    gzip: true
+  }));
+
+  server.listen(() => {
+    const port = server.address().port;
+    const options = {
+      uri: `http://localhost:${port}/gzip`,
+      headers: {
+        'accept-encoding': 'gzip'
+      }
+    };
+
+    request.get(options, (err, res) => {
+      t.ifError(err);
+      t.equal(res.statusCode, 200);
+      t.equal(res.headers['content-encoding'], 'gzip');
+    });
+  });
+  t.once('end', () => {
+    server.close();
+  });
+});


### PR DESCRIPTION
This patch simply trims whitespace when checking the `accept-encoding` header. This header is split on commas, but this leaves a leading space on every element except the first, at least in Firefox and Chromium. By coincidence, this has been working because the first encoding in the list matches right away, but this behavior is not guaranteed.

Another way this could be done would be to split on `', '` (comma and space), and this would work in Firefox and Chromium for sure, but I don't believe this is guaranteed either. Using `.trim()` is safer since `'foo' === 'foo'.trim()`. 