### PR TITLE
Set Brotli compression header

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -253,6 +253,12 @@ module.exports = function createMiddleware(_dir, _options) {
         contentType = mime.lookup(path.basename(file, '.gz'), defaultType);
       }
 
+      // Brotli compression header
+      if (file.endsWith('.br')) {
+        res.setHeader('Content-Encoding', 'br');
+        contentType = mime.lookup(path.basename(file, '.br'), defaultType);
+      }      
+
       if (typeof cacheControl === 'function') {
         cacheControl = cache(pathname);
       }


### PR DESCRIPTION
This PR is similar to https://github.com/jfhbrook/node-ecstatic/pull/228 but instead of compressing using Brotli, it just adds the header if a Brotli compressed file is found.

/cc @alexeagle