### PR TITLE
fix: leak on res aborted on non-range requests

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -344,6 +344,9 @@ module.exports = function createMiddleware(_dir, _options) {
       stream.on('error', (err) => {
         status['500'](res, next, { error: err });
       });
+      res.on('close', () => {
+        stream.destroy();
+      });
     }
 
 


### PR DESCRIPTION
Currently a non-range request which is aborted will leak a file descriptor. This PR fixes that.