### PR TITLE
fix: handle some edge cases with errors

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -296,7 +296,11 @@ module.exports = function createMiddleware(_dir, _options) {
 
         fstream = fs.createReadStream(file, { start, end });
         fstream.on('error', (err) => {
-          status['500'](res, next, { error: err });
+          if (handleError) {
+            status['500'](res, next, { error: err });
+          } else {
+            next(err);
+          }
         });
         res.on('close', () => {
           fstream.destroy();
@@ -342,7 +346,11 @@ module.exports = function createMiddleware(_dir, _options) {
 
       stream.pipe(res);
       stream.on('error', (err) => {
-        status['500'](res, next, { error: err });
+        if (handleError) {
+          status['500'](res, next, { error: err });
+        } else {
+          next(err);
+        }
       });
     }
 

--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -296,11 +296,7 @@ module.exports = function createMiddleware(_dir, _options) {
 
         fstream = fs.createReadStream(file, { start, end });
         fstream.on('error', (err) => {
-          if (handleError) {
-            status['500'](res, next, { error: err });
-          } else {
-            next(err);
-          }
+          status['500'](res, next, { error: err, handleError });
         });
         res.on('close', () => {
           fstream.destroy();
@@ -346,11 +342,7 @@ module.exports = function createMiddleware(_dir, _options) {
 
       stream.pipe(res);
       stream.on('error', (err) => {
-        if (handleError) {
-          status['500'](res, next, { error: err });
-        } else {
-          next(err);
-        }
+        status['500'](res, next, { error: err, handleError });
       });
     }
 

--- a/lib/ecstatic/show-dir/index.js
+++ b/lib/ecstatic/show-dir/index.js
@@ -42,11 +42,7 @@ module.exports = (opts) => {
 
     fs.stat(dir, (statErr, stat) => {
       if (statErr) {
-        if (handleError) {
-          status[500](res, next, { error: statErr });
-        } else {
-          next(statErr);
-        }
+        status[500](res, next, { error: statErr, handleError });
         return;
       }
 
@@ -55,11 +51,7 @@ module.exports = (opts) => {
         let files = _files;
 
         if (readErr) {
-          if (handleError) {
-            status[500](res, next, { error: readErr });
-          } else {
-            next(readErr);
-          }
+          status[500](res, next, { error: readErr, handleError });
           return;
         }
 
@@ -152,11 +144,7 @@ module.exports = (opts) => {
           if (path.resolve(dir, '..').slice(0, root.length) === root) {
             fs.stat(path.join(dir, '..'), (err, s) => {
               if (err) {
-                if (handleError) {
-                  status[500](res, next, { error: err });
-                } else {
-                  next(err);
-                }
+                status[500](res, next, { error: err, handleError });
                 return;
               }
               dirs.unshift(['..', s]);

--- a/lib/ecstatic/show-dir/index.js
+++ b/lib/ecstatic/show-dir/index.js
@@ -45,7 +45,7 @@ module.exports = (opts) => {
         if (handleError) {
           status[500](res, next, { error: statErr });
         } else {
-          next();
+          next(statErr);
         }
         return;
       }
@@ -58,7 +58,7 @@ module.exports = (opts) => {
           if (handleError) {
             status[500](res, next, { error: readErr });
           } else {
-            next();
+            next(readErr);
           }
           return;
         }
@@ -155,7 +155,7 @@ module.exports = (opts) => {
                 if (handleError) {
                   status[500](res, next, { error: err });
                 } else {
-                  next();
+                  next(err);
                 }
                 return;
               }

--- a/lib/ecstatic/status-handlers.js
+++ b/lib/ecstatic/status-handlers.js
@@ -53,6 +53,11 @@ exports['416'] = (res, next) => {
 
 // flagrant error
 exports['500'] = (res, next, opts) => {
+  if (!opts.handleError && next) {
+    next(opts.error);
+    return;
+  }
+
   if (res.headersSent) {
     res.destroy();
     return;

--- a/lib/ecstatic/status-handlers.js
+++ b/lib/ecstatic/status-handlers.js
@@ -53,6 +53,11 @@ exports['416'] = (res, next) => {
 
 // flagrant error
 exports['500'] = (res, next, opts) => {
+  if (res.headersSent) {
+    res.destroy();
+    return;
+  }
+
   res.statusCode = 500;
   res.setHeader('content-type', 'text/html');
   const error = String(opts.error.stack || opts.error || 'No specified error');

--- a/lib/ecstatic/status-handlers.js
+++ b/lib/ecstatic/status-handlers.js
@@ -53,6 +53,8 @@ exports['416'] = (res, next) => {
 
 // flagrant error
 exports['500'] = (res, next, opts) => {
+  res.statusCode = 500;
+
   if (!opts.handleError && next) {
     next(opts.error);
     return;
@@ -63,7 +65,6 @@ exports['500'] = (res, next, opts) => {
     return;
   }
 
-  res.statusCode = 500;
   res.setHeader('content-type', 'text/html');
   const error = String(opts.error.stack || opts.error || 'No specified error');
   const html = `${[
@@ -86,21 +87,25 @@ exports['500'] = (res, next, opts) => {
 // bad request
 exports['400'] = (res, next, opts) => {
   res.statusCode = 400;
-  res.setHeader('content-type', 'text/html');
-  const error = opts && opts.error ? String(opts.error) : 'Malformed request.';
-  const html = `${[
-    '<!doctype html>',
-    '<html>',
-    '  <head>',
-    '    <meta charset="utf-8">',
-    '    <title>400 Bad Request</title>',
-    '  </head>',
-    '  <body>',
-    '    <p>',
-    `      ${he.encode(error)}`,
-    '    </p>',
-    '  </body>',
-    '</html>',
-  ].join('\n')}\n`;
-  res.end(html);
+  if (typeof next === 'function') {
+    next();
+  } else {
+    res.setHeader('content-type', 'text/html');
+    const error = opts && opts.error ? String(opts.error) : 'Malformed request.';
+    const html = `${[
+      '<!doctype html>',
+      '<html>',
+      '  <head>',
+      '    <meta charset="utf-8">',
+      '    <title>400 Bad Request</title>',
+      '  </head>',
+      '  <body>',
+      '    <p>',
+      `      ${he.encode(error)}`,
+      '    </p>',
+      '  </body>',
+      '</html>',
+    ].join('\n')}\n`;
+    res.end(html);
+  }
 };


### PR DESCRIPTION
You can't write headers if headers are already sent... which is the case if e.g. the read stream fails (emit error) AFTER initial byte.

I'm not sure checking `writable` is enough and also if headers are sent we still need to destroy the response.