### PR TITLE
fix: on-finished

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -242,6 +242,10 @@ module.exports = function createMiddleware(_dir, _options) {
 
 
     function serve(stat) {
+      if (onFinished.isFinished(res)) {
+        return;
+      }
+
       // Do a MIME lookup, fall back to octet-stream and handle gzip
       // and brotli special case.
       const defaultType = opts.contentType || 'application/octet-stream';

--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -12,6 +12,7 @@ const version = require('../package.json').version;
 const status = require('./ecstatic/status-handlers');
 const generateEtag = require('./ecstatic/etag');
 const optsParser = require('./ecstatic/opts');
+const onFinished = require('on-finished');
 
 let ecstatic = null;
 
@@ -251,7 +252,6 @@ module.exports = function createMiddleware(_dir, _options) {
       const lastModified = (new Date(stat.mtime)).toUTCString();
       const etag = generateEtag(stat, weakEtags);
       let cacheControl = cache;
-      let stream = null;
       if (contentType) {
         charSet = mime.lookupCharset(contentType);
         if (charSet) {
@@ -287,20 +287,12 @@ module.exports = function createMiddleware(_dir, _options) {
           partialend ? parseInt(partialend, 10) : total - 1
         );
         const chunksize = (end - start) + 1;
-        let fstream = null;
 
         if (start > end || isNaN(start) || isNaN(end)) {
           status['416'](res, next);
           return;
         }
 
-        fstream = fs.createReadStream(file, { start, end });
-        fstream.on('error', (err) => {
-          status['500'](res, next, { error: err });
-        });
-        res.on('close', () => {
-          fstream.destroy();
-        });
         res.writeHead(206, {
           'Content-Range': `bytes ${start}-${end}/${total}`,
           'Accept-Ranges': 'bytes',
@@ -310,7 +302,16 @@ module.exports = function createMiddleware(_dir, _options) {
           'last-modified': lastModified,
           etag,
         });
-        fstream.pipe(res);
+
+        const stream = fs
+          .createReadStream(file, { start, end })
+          .on('error', (err) => {
+            status['500'](res, next, { error: err });
+          })
+          .pipe(res);
+        onFinished(res, () => {
+          stream.destroy();
+        });
         return;
       }
 
@@ -338,11 +339,14 @@ module.exports = function createMiddleware(_dir, _options) {
         return;
       }
 
-      stream = fs.createReadStream(file);
-
-      stream.pipe(res);
-      stream.on('error', (err) => {
-        status['500'](res, next, { error: err });
+      const stream = fs
+        .createReadStream(file)
+        .on('error', (err) => {
+          status['500'](res, next, { error: err });
+        })
+        .pipe(res);
+      onFinished(res, () => {
+        stream.destroy();
       });
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ecstatic",
-  "version": "3.3.1",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -650,8 +650,7 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-      "dev": true
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -2913,7 +2912,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true,
       "requires": {
         "ee-first": "1.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "he": "^1.1.1",
     "mime": "^2.4.1",
     "minimist": "^1.1.0",
+    "on-finished": "^2.3.0",
     "url-join": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Use on-finished. `close` is not always emitted in every scenario in some "older" versions of node. I don't remember the exact specifics.