### PR TITLE
fix: response can be aborted during e.g. fs.stat and hasGzipId12

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -239,8 +239,12 @@ module.exports = function createMiddleware(_dir, _options) {
       return;
     }
 
-
     function serve(stat) {
+      if (req.aborted || res.finished) {
+        // Response was aborted (by client or server) while we were doing other async stuff.
+        return;
+      }
+
       // Do a MIME lookup, fall back to octet-stream and handle gzip
       // and brotli special case.
       const defaultType = opts.contentType || 'application/octet-stream';


### PR DESCRIPTION
Request/Response can be aborted while doing async stuff... handle it.

Would prefer to use `isFinished` but I've proposed using the `on-finished` package in another PR so I'll leave the "modern" node way here.