### PR TITLE
Added "--host" option.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -69,3 +69,4 @@ Listed in no particular order:
 * Jade Michael Thornton @thornjad <jade@jmthorton.net>
 * @BigBlueHat
 * Robert Nagy @ronag <ronagy@icloud.com>
+* Ji WenCong <taiki_akita@163.com>

--- a/README.md
+++ b/README.md
@@ -121,6 +121,13 @@ serve the current dir. Ecstatic also respects the PORT environment variable.
 
 `opts.root` is the directory you want to serve up.
 
+### `opts.host`
+### `--host {host}`
+
+In CLI mode, `opts.host` is the host you want ecstatic to listen to. Defaults
+to 0.0.0.0. This can be overridden with the `--host` flag or with the HOST
+environment variable.
+
 ### `opts.port`
 ### `--port {port}`
 

--- a/lib/bin.js
+++ b/lib/bin.js
@@ -18,7 +18,7 @@ const opts = minimist(process.argv.slice(2), {
 });
 const envPORT = parseInt(process.env.PORT, 10);
 const port = envPORT > 1024 && envPORT <= 65536 ? envPORT : opts.port || opts.p || 8000;
-const host = opts.host || '0.0.0.0';
+const host = process.env.HOST || opts.host || '0.0.0.0';
 const dir = opts.root || opts._[0] || process.cwd();
 
 if (opts.help || opts.h) {

--- a/lib/bin.js
+++ b/lib/bin.js
@@ -18,15 +18,17 @@ const opts = minimist(process.argv.slice(2), {
 });
 const envPORT = parseInt(process.env.PORT, 10);
 const port = envPORT > 1024 && envPORT <= 65536 ? envPORT : opts.port || opts.p || 8000;
+const host = opts.host || "0.0.0.0";
 const dir = opts.root || opts._[0] || process.cwd();
 
 if (opts.help || opts.h) {
   console.error('usage: ecstatic [dir] {options} --port PORT');
   console.error('see https://npm.im/ecstatic for more docs');
 } else {
-  http.createServer(ecstatic(dir, opts))
-    .listen(port, () => {
-      console.log(`ecstatic serving ${dir} at http://0.0.0.0:${port}`);
+  let server = http.createServer(ecstatic(dir, opts))
+    .listen(port, host, () => {
+      let bind = server.address();
+      console.log(`ecstatic serving ${dir} at http://${bind.address}:${bind.port}`);
     })
   ;
 }

--- a/lib/bin.js
+++ b/lib/bin.js
@@ -18,16 +18,16 @@ const opts = minimist(process.argv.slice(2), {
 });
 const envPORT = parseInt(process.env.PORT, 10);
 const port = envPORT > 1024 && envPORT <= 65536 ? envPORT : opts.port || opts.p || 8000;
-const host = opts.host || "0.0.0.0";
+const host = opts.host || '0.0.0.0';
 const dir = opts.root || opts._[0] || process.cwd();
 
 if (opts.help || opts.h) {
   console.error('usage: ecstatic [dir] {options} --port PORT');
   console.error('see https://npm.im/ecstatic for more docs');
 } else {
-  let server = http.createServer(ecstatic(dir, opts))
+  const server = http.createServer(ecstatic(dir, opts))
     .listen(port, host, () => {
-      let bind = server.address();
+      const bind = server.address();
       console.log(`ecstatic serving ${dir} at http://${bind.address}:${bind.port}`);
     })
   ;


### PR DESCRIPTION
Added a "--host" option that you can use to specify the host (address) that Ecstatic listened to.