### PR TITLE
Backport vuln fix to major version 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+2019/05/02 Version 3.3.2
+- Backport Open Redirect vulnerability fix
+
 2019/02/10 Version 3.3.1
 - Publish via linux to hopefully fix #238
 

--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -19,7 +19,7 @@ let ecstatic = null;
 function decodePathname(pathname) {
   const pieces = pathname.replace(/\\/g, '/').split('/');
 
-  return pieces.map((rawPiece) => {
+  return path.normalize(pieces.map((rawPiece) => {
     const piece = decodeURIComponent(rawPiece);
 
     if (process.platform === 'win32' && /\\/.test(piece)) {
@@ -27,7 +27,7 @@ function decodePathname(pathname) {
     }
 
     return piece;
-  }).join('/');
+  }).join('/'));
 }
 
 
@@ -376,8 +376,9 @@ module.exports = function createMiddleware(_dir, _options) {
             return;
           }
 
+
           // 302 to / if necessary
-          if (!parsed.pathname.match(/\/$/)) {
+          if (!pathname.match(/\/$/)) {
             res.statusCode = 302;
             const q = parsed.query ? `?${parsed.query}` : '';
             res.setHeader('location', `${parsed.pathname}/${q}`);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Joshua Holbrook <josh@nodejitsu.com> (http://jesusabdullah.net)",
   "name": "ecstatic",
   "description": "A simple static file server middleware",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "homepage": "https://github.com/jfhbrook/node-ecstatic",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Cherry-picked the patch commit that resolved the [Open Redirect vulnerability](https://www.npmjs.com/advisories/830) announced.