### PR TITLE
Fix redirections on Windows

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -28,7 +28,7 @@ function decodePathname(pathname) {
     }
 
     return piece;
-  }).join('/'));
+  }).join('/')).replace(/\\/g, '/');
 }
 
 


### PR DESCRIPTION
Thank you for fixing Backport Open Redirect vulnerability, but it breaks on Windows machines. 

`path.normalize("/path/to/file")` returns `\path\to\file` on Windows, and it doesn't work in browsers.